### PR TITLE
Disable Proguard in sample app, mention in README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -28,12 +28,23 @@ For iOS:
         "${FRAMEWORKS}/SquareMobilePaymentsSDK.framework/setup"
         ```
 
-For Android, you need to configure the SDK version:
+For Android:
 1. Modify your `/android/build.gradle`
    - Add `squareSdkVersion = "2.0.1"` inside the `ext {...}` block
    - Add `maven { url 'https://sdk.squareup.com/public/android/' }` inside the `allprojects`'s `repositories {...}` block
 2. Modify your `/android/app/build.gradle`
    - Add `implementation("com.squareup.sdk:mobile-payments-sdk:$squareSdkVersion")` inside the `dependencies{...}` block
+3. Disable Proguard by adding the following to your `/android/app/build.gradle`:
+```gradle
+android {
+    buildTypes {
+        release {
+            minifyEnabled false
+            shrinkResources false
+        }
+    }
+}
+```
 
 You can also refer to [MPSDK Android Quickstart](https://developer.squareup.com/docs/mobile-payments-sdk/android#1-install-the-sdk-and-dependencies)'s SDK installation section.
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -38,6 +38,9 @@ android {
         release {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
+            // Disable Proguard
+            minifyEnabled false
+            shrinkResources false
         }
     }
 }


### PR DESCRIPTION
Mobile Payment SDK doesn't support Proguard for code optimization, as it might remove some critical bytecode from the library. 
This PR updates the sample app to disable Proguard and mentions the required change in README.md

Addresses https://github.com/square/mobile-payments-sdk-flutter/issues/9