### PR TITLE
Potential fix for iOS release build mode

### DIFF
--- a/ios/square_mobile_payments_sdk.podspec
+++ b/ios/square_mobile_payments_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'square_mobile_payments_sdk'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'Square Mobile Payments SDK.'
   s.description      = <<-DESC
 Allows developers to take in-person payments using Square hardware.

--- a/ios/square_mobile_payments_sdk.podspec
+++ b/ios/square_mobile_payments_sdk.podspec
@@ -18,7 +18,7 @@ Allows developers to take in-person payments using Square hardware.
   s.platform = :ios, '15.0'
 
   s.dependency "SquareMobilePaymentsSDK", "~> 2.1.0"
-  s.dependency "MockReaderUI", "~> 2.1.0", configurations: ['Debug']
+  s.dependency "MockReaderUI", "~> 2.1.0"
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## Problem
Our app, as well as the example app, fails to build on iOS in release mode due to `MockReaderUI` being unavailable. This is particularly relevant for Flutter developers who want to use the plugin without manually managing iOS dependencies -- although I was never able to get it to build by adding `pod MockReaderUI` to the app's Podfile.

```
➜  example git:(main) ✗ pwd              
/Users/--------/Workspace/------/mobile-payments-sdk-flutter/example

➜  example git:(main) ✗ flutter build ios
Building com.squareup.squareMobilePaymentsSdkExample for device (ios-release)...
Warning: Missing build name (CFBundleShortVersionString).
Warning: Missing build number (CFBundleVersion).
Action Required: You must set a build name and number in the pubspec.yaml file version field before submitting to the App Store.
Developer identity "Apple Development: ------------ (---------)" selected for iOS code signing
Running Xcode build...                                                  
Xcode build done.                                           43.2s
Failed to build iOS app
Swift Compiler Error (Xcode): No such module 'MockReaderUI'
/Users/-------/Workspace/-------/mobile-payments-sdk-flutter/ios/Classes/Modules/ReaderModule.swift:2:7
```

## Solution
Added conditional compilation for `MockReaderUI` related code using `#if DEBUG` to ensure the plugin builds successfully in both debug and release modes. This is a common pattern in iOS development for handling debug-only features.

The solution doesn't require any additional pod or SPM dependencies in the app's Podfile.

## Testing
- Verified successful builds in both debug and release modes
- Tested without any additional pod or SPM dependencies

## Note
While this solution resolves the immediate build issue, I'm open to feedback if there's a more idiomatic approach that the Square team would prefer. Possibly something more on the flutter plugin or cocoapods side of things.

I also haven't tested that MockReader works in flutter debug mode but I assume it would. I thought I'd go ahead and put this up since it got us building release mode. Also wanted to add, this isn't critical for us since we can use my fork in the pubspec.yaml.