### PR TITLE
Cesarp/fix to lower issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025.7.1
+
+Upgrade native SDKs: Android 2.3.0, iOS: 2.2.3
+
 ## 2025.6.1
 
 Add Offline payments support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2025.7.1
 
 Upgrade native SDKs: Android 2.3.0, iOS: 2.2.3
+Remove deprecated use of toLower
 
 ## 2025.6.1
 

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/PaymentExtension.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/PaymentExtension.kt
@@ -129,7 +129,7 @@ fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
   fun Money.toMoneyMap(): Map<String, Any?> {
     return mapOf(
       "amount" to amount,
-      "currencyCode" to currencyCode.name.toLowerCase() // to build Money Dart obj
+      "currencyCode" to currencyCode.name.lowercase() // to build Money Dart obj
     )
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_mobile_payments_sdk
 description: "Square Mobile Payments SDK. Allows developers to take in-person payments using Square hardware."
-version: 2025.6.2
+version: 2025.7.1
 homepage: https://github.com/square/mobile-payments-sdk-flutter
 
 environment:


### PR DESCRIPTION
 [Deprecated method toLowerCase(). Use lowercase() for Kotlin versions < 1.0](https://github.com/square/mobile-payments-sdk-flutter/issues/46)