### PR TITLE
fix: resolve flutter analyzer errors and warnings

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,5 @@
 PODS:
-  - device_info_plus (0.0.1):
-    - Flutter
   - Flutter (1.0.0)
-  - integration_test (0.0.1):
-    - Flutter
   - MockReaderUI (2.4.0)
   - permission_handler_apple (9.3.0):
     - Flutter
@@ -14,9 +10,7 @@ PODS:
   - SquareMobilePaymentsSDK (2.4.0)
 
 DEPENDENCIES:
-  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
-  - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - square_mobile_payments_sdk (from `.symlinks/plugins/square_mobile_payments_sdk/ios`)
 
@@ -26,21 +20,15 @@ SPEC REPOS:
     - SquareMobilePaymentsSDK
 
 EXTERNAL SOURCES:
-  device_info_plus:
-    :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
-  integration_test:
-    :path: ".symlinks/plugins/integration_test/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   square_mobile_payments_sdk:
     :path: ".symlinks/plugins/square_mobile_payments_sdk/ios"
 
 SPEC CHECKSUMS:
-  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   MockReaderUI: e527a5bc446b95e8cd5ddb4c565fc7d614d38a0f
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   square_mobile_payments_sdk: 666c46acf4d2e25de12a4c6b6fbed2df6d7f3297

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C50F82702E06160F002FAE15 /* MockReaderUI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBC07E6F2D4D043200614FC8 /* MockReaderUI.xcframework */; };
 		C50F82722E06161C002FAE15 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24A8D3B85719B8F5F1207F52 /* Pods_Runner.framework */; };
 		CF0F8031407930AE48819C35 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A62B4196D23B9B6BFAAE7D66 /* Pods_RunnerTests.framework */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,6 +57,7 @@
 		DBC07E6F2D4D043200614FC8 /* MockReaderUI.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:EYF346PHUG:Block, Inc."; lastKnownFileType = wrapper.xcframework; name = MockReaderUI.xcframework; path = Pods/MockReaderUI/MockReaderUI.xcframework; sourceTree = "<group>"; };
 		EAD182942BA1960D3E096863 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		FECF3E05CC39E0F4FDE0D353 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				C50F82702E06160F002FAE15 /* MockReaderUI.xcframework in Frameworks */,
 				C50F826D2E061609002FAE15 /* SquareMobilePaymentsSDK.xcframework in Frameworks */,
 				C50F82722E06161C002FAE15 /* Pods_Runner.framework in Frameworks */,
@@ -115,6 +118,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -182,6 +186,9 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -208,6 +215,9 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -758,6 +768,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/example/lib/donut_counter_screen.dart
+++ b/example/lib/donut_counter_screen.dart
@@ -47,18 +47,6 @@ class _DonutCounterScreenState extends State<DonutCounterScreen> {
     }
   }
 
-  _onTapToPay() async {
-    print("testing TTP");
-    try {
-      bool isAppleAccountLinked = await _squareMobilePaymentsSdkPlugin
-          .tapToPaySettings
-          .isDeviceCapable();
-      print("isAppleAccountLinked ");
-    } catch (e, stackTrace) {
-      print("Exception reader: $e");
-    }
-  }
-
   void showPaymentDialog(BuildContext context, Payment payment) {
     showDialog(
       context: context,

--- a/example/lib/permissions_screen.dart
+++ b/example/lib/permissions_screen.dart
@@ -88,7 +88,6 @@ class _PermissionsScreenState extends State<PermissionsScreen> {
   Future<void> authorizeSDK() async {
     String accessToken = "YOUR_ACCESS_TOKEN";
     String locationId = "YOUR_LOCATION_ID";
-    String response;
 
     setState(() {
       _signInState = SignInState.loading;

--- a/test/square_mobile_payments_sdk_test.dart
+++ b/test/square_mobile_payments_sdk_test.dart
@@ -1,29 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:square_mobile_payments_sdk/square_mobile_payments_sdk.dart';
 import 'package:square_mobile_payments_sdk/square_mobile_payments_sdk_platform_interface.dart';
 import 'package:square_mobile_payments_sdk/square_mobile_payments_sdk_method_channel.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 class MockSquareMobilePaymentsSdkPlatform
-    with MockPlatformInterfaceMixin
-    implements SquareMobilePaymentsSdkPlatform {
-
-  @override
-  Future<String?> getPlatformVersion() => Future.value('42');
-}
+    extends SquareMobilePaymentsSdkPlatform
+    with MockPlatformInterfaceMixin {}
 
 void main() {
   final SquareMobilePaymentsSdkPlatform initialPlatform = SquareMobilePaymentsSdkPlatform.instance;
 
   test('$MethodChannelSquareMobilePaymentsSdk is the default instance', () {
     expect(initialPlatform, isInstanceOf<MethodChannelSquareMobilePaymentsSdk>());
-  });
-
-  test('getPlatformVersion', () async {
-    SquareMobilePaymentsSdk squareMobilePaymentsSdkPlugin = SquareMobilePaymentsSdk();
-    MockSquareMobilePaymentsSdkPlatform fakePlatform = MockSquareMobilePaymentsSdkPlatform();
-    SquareMobilePaymentsSdkPlatform.instance = fakePlatform;
-
-    expect(await squareMobilePaymentsSdkPlugin.getPlatformVersion(), '42');
   });
 }


### PR DESCRIPTION
## Summary

- **Test file** (`test/square_mobile_payments_sdk_test.dart`): Mock class was using `implements SquareMobilePaymentsSdkPlatform`, which required concrete implementations of all 29 platform methods — fixed by switching to `extends ... with MockPlatformInterfaceMixin` so it inherits default implementations. Also removed the stale `getPlatformVersion` test since that method no longer exists on `SquareMobilePaymentsSdk` (replaced by manager classes).
- **`example/lib/donut_counter_screen.dart`**: Removed the unreferenced `_onTapToPay` private method (dead code) — also eliminates the `unused_local_variable` (`isAppleAccountLinked`) and `unused_catch_stack` (`stackTrace`) warnings inside it.
- **`example/lib/permissions_screen.dart`**: Removed the unused `String response;` declaration in `authorizeSDK()`.
- **iOS auto-generated files**: Updated `AppFrameworkInfo.plist`, `Podfile.lock`, `project.pbxproj`, and `Runner.xcscheme` to reflect current Flutter tooling (Swift PM integration, dropped stale pods).

## Result

`flutter analyze` goes from **3 errors + 4 warnings → 0 errors + 0 warnings**.

## Test plan

- [ ] Run `flutter analyze` — expect 0 errors and 0 warnings
- [ ] Run `flutter test` — existing test passes