### PR TITLE
Add unknown to ReaderChange enum (#66)

### DIFF
--- a/lib/src/models/enums.dart
+++ b/lib/src/models/enums.dart
@@ -140,6 +140,7 @@ enum ReaderChange {
   batteryThreshold,
   batteryCharging,
   firmwareProgress,
+  unknown
 }
 
 enum ReaderFirmwareUpdateError {

--- a/lib/src/models/models.g.dart
+++ b/lib/src/models/models.g.dart
@@ -652,4 +652,5 @@ const _$ReaderChangeEnumMap = {
   ReaderChange.batteryThreshold: 'batteryThreshold',
   ReaderChange.batteryCharging: 'batteryCharging',
   ReaderChange.firmwareProgress: 'firmwareProgress',
+  ReaderChange.unknown: 'unknown',
 };


### PR DESCRIPTION
This PR adds support for an unmapped ReaderChange event value (unknown) in the Tap to Pay flow of the Square Mobile Payments Flutter SDK.

Problem

When the app transitions between background and foreground, the Tap to Pay reader reconnects and emits a ReaderChange event.

Currently, this event is value of unknown, which is not included in the ReaderChange enum. This causes a deserialization failure and we miss the event. Error:

Invalid argument(s): ⁠ unknown ⁠ is not one of the supported values: batteryDidBeginCharging, batteryDidEndCharging, batteryLevelDidChange, cardInserted, cardRemoved, firmwareUpdateDidFail, firmwareUpdatePercentDidChange, changedState, added, removed, batteryThreshold, batteryCharging, firmwareProgress

Solution

This PR adds the missing unknown value to the ReaderChange enum, allowing the SDK to safely deserialize all incoming events.

Benefits
Ensures the event stream remains stable during app lifecycle transitions (background ↔ foreground)
Preserves access to the reader reference included in the event
Allows consumers to fetch the latest reader state if needed, even when the event type is not explicitly mapped

It will be ideal that Native IOS SDK send the correct eventName but with this mapping at least we known that something "unknown" change on the Reader and we can fetch his current status.


