### PR TITLE
Upgrade native sdks 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2026.2.4
+## 2026.3.1
 
 Upgrade native SDKs: Android 2.4.0, iOS: 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026.4.1
+
+Upgrade native SDKs: Android 2.5.0, iOS: 2.5.0
+
 ## 2026.3.1
 
 Upgrade native SDKs: Android 2.4.0, iOS: 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## 2026.5.1
 
-Upgrade native SDKs: Android 2.5.0, iOS: 2.5.0
-- Updated Android and iOS plugin modules for reader and settings flows.
-- Updated Flutter platform interface and method channel mappings.
-- Regenerated model serialization/freezed files for the 2.5.0 SDK changes.
+* Upgrade Android and iOS native SDK to `2.5.0`
+* Add `SettingsManager.isShowingSettings()` to check whether the Settings screen is currently presented
+* Add `SettingsManager.closeSettings()` to programmatically dismiss the Settings screen
+* Add `ReaderManager.readerSettings()` which returns a new `ReaderSettings` object (`isReducedChargingModeEnabled`, `preferredFirmwareUpdateTime`). Adds a new `TimeOfDay` type (`hour`, `minute`) used by `preferredFirmwareUpdateTime`
+* **Breaking:** `ReaderInfo.firmwareVersion` and `ReaderInfo.firmwarePercent` have been replaced by a single `ReaderInfo.firmwareInfo` object of shape `{ version, updatePercentage }`, mirroring the 2.5.0 native API
+* **Breaking (Android):** Removed `ALIPAY`, `CASH_APP`, `SUICA`, `ID`, and `QUICPAY` from the mapped `Card.Brand` values — these were removed in native SDK `2.5.0`
 
 ## 2026.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 2026.4.1
+## 2026.5.1
 
 Upgrade native SDKs: Android 2.5.0, iOS: 2.5.0
+- Updated Android and iOS plugin modules for reader and settings flows.
+- Updated Flutter platform interface and method channel mappings.
+- Regenerated model serialization/freezed files for the 2.5.0 SDK changes.
 
 ## 2026.3.1
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version = "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "2.2.21"
-    ext.squareSdkVersion = "2.4.0"
+    ext.squareSdkVersion = "2.5.0"
     repositories {
         google()
         mavenCentral()

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/SquareMobilePaymentsSdkPlugin.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/SquareMobilePaymentsSdkPlugin.kt
@@ -92,6 +92,9 @@ class SquareMobilePaymentsSdkPlugin : FlutterPlugin, MethodCallHandler, StreamHa
       "removeReaderChangedCallback" -> ReaderModule.removeReaderChangedCallback(result)
       "pairReader" -> ReaderModule.pairReader(result)
       "stopPairing" -> ReaderModule.stopPairing(result)
+      "readerSettings" -> ReaderModule.readerSettings(result)
+      "closeSettings" -> SettingsModule.closeSettings(result)
+      "isShowingSettings" -> SettingsModule.isShowingSettings(result)
       else -> result.notImplemented()
     }
   }

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/ErrorExtensions.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/ErrorExtensions.kt
@@ -15,6 +15,7 @@ fun AuthorizeErrorCode.toAuthorizeErrorCodeName(): String = when (this) {
     AuthorizeErrorCode.NO_NETWORK -> "noNetwork"
     AuthorizeErrorCode.UNSUPPORTED_COUNTRY -> "unsupportedCountry"
     AuthorizeErrorCode.USAGE_ERROR -> "usageError"
+    AuthorizeErrorCode.OBSOLETE_SDK -> "obsoleteSdk"
 }
 
 // settings
@@ -33,4 +34,5 @@ fun PaymentErrorCode.toPaymentErrorCodeName(): String = when (this) {
         PaymentErrorCode.DEVICE_CLOCK_SKEWED -> "deviceClockSkewed"
         PaymentErrorCode.USAGE_ERROR -> "usageError"
         PaymentErrorCode.CONSENT_NOT_PROVIDED -> "consentNotProvided"
+        PaymentErrorCode.OBSOLETE_SDK -> "obsoleteSdk"
 }

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/PaymentExtension.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/PaymentExtension.kt
@@ -6,8 +6,6 @@ import com.squareup.sdk.mobilepayments.payment.Card
 import com.squareup.sdk.mobilepayments.payment.CardPaymentDetails
 import com.squareup.sdk.mobilepayments.payment.ExternalPaymentDetails
 import com.squareup.sdk.mobilepayments.payment.PaymentProcessingFee
-import com.squareup.sdk.mobilepayments.payment.SquareAccountDetails
-import com.squareup.sdk.mobilepayments.payment.DigitalWalletDetails
 import com.squareup.sdk.mobilepayments.payment.CashPaymentDetails
 
 import java.text.SimpleDateFormat
@@ -23,7 +21,6 @@ fun Payment.SourceType.toName(): String {
     Payment.SourceType.BANK_ACCOUNT -> "bankAccount"
     Payment.SourceType.CARD_ON_FILE -> "cardOnFile"
     Payment.SourceType.SQUARE_ACCOUNT -> "squareAccount"
-    else -> "unknown"
   }
 }
 
@@ -34,7 +31,6 @@ fun Payment.OfflineStatus.toOfflineStatusName(): String {
     Payment.OfflineStatus.FAILED_TO_UPLOAD -> "failedToUpload"
     Payment.OfflineStatus.FAILED_TO_PROCESS -> "failedToProcess"
     Payment.OfflineStatus.PROCESSED -> "processed"
-    else -> "unknown"
   }
 }
 
@@ -45,7 +41,6 @@ fun CardPaymentDetails.EntryMethod.toEntryMethodName(): String {
     CardPaymentDetails.EntryMethod.EMV -> "emv"
     CardPaymentDetails.EntryMethod.CONTACTLESS -> "contactless"
     CardPaymentDetails.EntryMethod.ON_FILE -> "onFile"
-    else -> "unknown"
   }
 }
 
@@ -61,16 +56,10 @@ fun Card.Brand.toBrandName(): String {
     Card.Brand.JCB -> "jcb"
     Card.Brand.CHINA_UNIONPAY -> "chinaUnionPay"
     Card.Brand.SQUARE_GIFT_CARD -> "squareGiftCard"
-    Card.Brand.ALIPAY -> "alipay"
-    Card.Brand.CASH_APP -> "cashApp"
     Card.Brand.EFTPOS -> "eftpos"
     Card.Brand.FELICA -> "felica"
     Card.Brand.INTERAC -> "interac"
     Card.Brand.SQUARE_CAPITAL_CARD -> "squareCapitalCard"
-    Card.Brand.SUICA -> "suica"
-    Card.Brand.ID -> "id"
-    Card.Brand.QUICPAY -> "quicpay"
-    else -> "unknown"
   }
 }
 
@@ -118,10 +107,6 @@ fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
       "teamMemberId" to teamMemberId,
       //"capabilities" to capabilities.toMap(),
       "receiptNumber" to receiptNumber,
-      "remainingBalance" to remainingBalance?.toMoneyMap(),
-      "squareAccountDetails" to squareAccountDetails?.toAccountMap(),
-      "digitalWalletDetails" to digitalWalletDetails?.toWalletMap(),
-
       "totalMoney" to totalMoney?.toMoneyMap()
     )
   }
@@ -171,21 +156,6 @@ fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
     )
   }
 
-
-  fun DigitalWalletDetails.toWalletMap(): Map<String, Any?> {
-    return mapOf(
-      "walletBrand" to walletBrand?.name,
-      "buyerId" to buyerId
-    )
-  }
-
-  fun SquareAccountDetails.toAccountMap(): Map<String, Any?> {
-    return mapOf(
-      "paymentSourceToken" to paymentSourceToken,
-      "errors" to errors?.map { it.toErrorDetailsMap() }
-    )
-  }
-
   fun PaymentProcessingFee.toProcessingFeeMap(): Map<String, Any?> {
     return mapOf(
       "effectiveAt" to effectiveAt.time.toString(),
@@ -202,13 +172,8 @@ fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
       "authorizationCode" to authorizationCode,
       "applicationId" to applicationId,
       "applicationName" to applicationName,
-      "applicationCounter" to applicationCounter,
-      "panSequenceNumber" to panSequenceNumber,
       "verificationMethod" to verificationMethod?.name,
       "verificationResults" to verificationResults?.name,
-      "accountType" to accountType?.name,
-      "remainingBalanceAmountMoney" to remainingBalanceAmountMoney?.toMoneyMap(),
-      "felicaSprwdId" to felicaSprwdId
     )
   }
 

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/ReaderExtension.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/ReaderExtension.kt
@@ -1,9 +1,11 @@
 package com.squareup.square_mobile_payments_sdk.extensions
 
 import com.squareup.sdk.mobilepayments.cardreader.CardEntryMethod
-import com.squareup.sdk.mobilepayments.cardreader.ReaderInfo
-import com.squareup.sdk.mobilepayments.cardreader.ReaderChangedEvent
 import com.squareup.sdk.mobilepayments.cardreader.PairingHandle.StopResult
+import com.squareup.sdk.mobilepayments.cardreader.ReaderChangedEvent
+import com.squareup.sdk.mobilepayments.cardreader.ReaderInfo
+import com.squareup.sdk.mobilepayments.cardreader.ReaderSettings
+import com.squareup.sdk.mobilepayments.core.TimeOfDay
 
 fun ReaderInfo.toReaderInfoMap(): Map<String, Any?> {
     return mapOf(
@@ -13,14 +15,22 @@ fun ReaderInfo.toReaderInfoMap(): Map<String, Any?> {
         "name" to name,
         "batteryStatus" to batteryStatus?.toBatteryStatusMap(),
         "firmwareInfo" to mapOf(
-            "version" to firmwareVersion,
-            "updatePercentage" to (firmwarePercent ?: 0),
+            "version" to firmwareInfo.version,
+            "updatePercentage" to (firmwareInfo.updateStatus.toPercent() ?: 0),
         ),
         "supportedInputMethods" to supportedCardEntryMethods.map { it.toEntryMethodName() },
         "isForgettable" to isForgettable,
         "isBlinkable" to isBlinkable,
         "statusInfo" to status.toStatusMap()
     )
+}
+
+fun ReaderInfo.FirmwareUpdateStatus.toPercent(): Int? {
+   return  when (this) {
+     is ReaderInfo.FirmwareUpdateStatus.InProgress -> this.updatePercentage
+     is ReaderInfo.FirmwareUpdateStatus.None -> null
+     is ReaderInfo.FirmwareUpdateStatus.Pending -> null
+   }
 }
 
 fun ReaderInfo.Status.toStatusMap(): Map<String, Any?> {
@@ -78,18 +88,6 @@ fun ReaderInfo.Model.toModelName(): String {
     ReaderInfo.Model.TAP_TO_PAY -> "tapToPay"
   }
 }
-
-fun ReaderInfo.State.toStateName(): String {
-  return when(this) {
-    is ReaderInfo.State.Ready ->"ready"
-    is ReaderInfo.State.Disabled ->"disabled"
-    is ReaderInfo.State.Connecting ->"connecting"
-    is ReaderInfo.State.Disconnected ->"disconnected"
-    is ReaderInfo.State.FailedToConnect->"failedToConnect"
-    is ReaderInfo.State.UpdatingFirmware ->"updatingFirmware"
-  }
-}
-
 fun ReaderInfo.BatteryStatus.toBatteryStatusMap(): Map<String, Any> {
     return mapOf(
         "isCharging" to isCharging,
@@ -128,4 +126,18 @@ fun StopResult.toStopResultName(): String {
     StopResult.ALREADY_COMPLETE -> "alreadyComplete"
     StopResult.STOPPED -> "stopped"
   }
+}
+
+fun ReaderSettings.toReaderSettingsMap(): Map<String, Any?> {
+  return mapOf (
+    "isReducedChargingModeEnabled" to isReducedChargingModeEnabled,
+    "preferredFirmwareUpdateTime" to preferredFirmwareUpdateTime?.toTimeOfDayMap()
+  )
+}
+
+fun TimeOfDay.toTimeOfDayMap(): Map<String, Int> {
+  return mapOf (
+    "hour" to hour,
+    "minute" to minute
+  )
 }

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/modules/ReaderModule.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/modules/ReaderModule.kt
@@ -8,6 +8,7 @@ import com.squareup.sdk.mobilepayments.cardreader.PairingHandle
 import com.squareup.sdk.mobilepayments.cardreader.PairingHandle.StopResult
 import com.squareup.sdk.mobilepayments.mockreader.ui.MockReaderUI
 import com.squareup.square_mobile_payments_sdk.extensions.toReaderInfoMap
+import com.squareup.square_mobile_payments_sdk.extensions.toReaderSettingsMap
 import com.squareup.square_mobile_payments_sdk.extensions.toChangedEventMap
 import com.squareup.square_mobile_payments_sdk.extensions.toStopResultName
 import com.squareup.sdk.mobilepayments.MobilePaymentsSdk
@@ -132,6 +133,11 @@ class ReaderModule {
                 globalPairingHandle = null
                 result.success(stopResult?.toStopResultName())
             }
+        }
+
+        @JvmStatic
+        fun readerSettings(result: MethodChannel.Result) {
+            result.success(readerManager.readerSettings.toReaderSettingsMap())
         }
     }
 }

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/modules/SettingsModule.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/modules/SettingsModule.kt
@@ -63,11 +63,21 @@ class SettingsModule {
             val consentState = settingsManager.trackingConsentState
             result.success(consentState.name)
         }
+
         @JvmStatic
         fun updateTrackingConsent(result: MethodChannel.Result, granted: Boolean) {
             settingsManager.updateTrackingConsent(granted)
             result.success(true)
         }
 
+        @JvmStatic
+        fun closeSettings(result: MethodChannel.Result) {
+          result.success(settingsManager.closeSettings())
+        }
+
+        @JvmStatic
+        fun isShowingSettings(result: MethodChannel.Result) {
+          result.success(settingsManager.isShowingSettings())
+        }
     }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -11,6 +11,12 @@ android {
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
+    packaging {
+        resources {
+            pickFirsts += ['META-INF/versions/9/OSGI-INF/MANIFEST.MF']
+        }
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
@@ -31,7 +37,7 @@ android {
     }
 
     dependencies {
-        implementation("com.squareup.sdk:mobile-payments-sdk:2.4.0")
+        implementation("com.squareup.sdk:mobile-payments-sdk:2.5.0")
     }
 
     buildTypes {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - MockReaderUI (2.4.0)
+  - MockReaderUI (2.5.0)
   - permission_handler_apple (9.3.0):
     - Flutter
   - square_mobile_payments_sdk (0.0.2):
     - Flutter
-    - MockReaderUI (~> 2.4.0)
-    - SquareMobilePaymentsSDK (~> 2.4.0)
-  - SquareMobilePaymentsSDK (2.4.0)
+    - MockReaderUI (~> 2.5.0)
+    - SquareMobilePaymentsSDK (~> 2.5.0)
+  - SquareMobilePaymentsSDK (2.5.0)
 
 DEPENDENCIES:
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
@@ -41,10 +41,10 @@ SPEC CHECKSUMS:
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  MockReaderUI: e527a5bc446b95e8cd5ddb4c565fc7d614d38a0f
+  MockReaderUI: 651252bf60bffc2699866448a6fb7250c06be785
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  square_mobile_payments_sdk: 666c46acf4d2e25de12a4c6b6fbed2df6d7f3297
-  SquareMobilePaymentsSDK: 53cd315a537037377cd364edc874bf75782239eb
+  square_mobile_payments_sdk: 3b999ca0e82fa416fab4c4c18ce0296f3585969c
+  SquareMobilePaymentsSDK: 61d783cb2ef4b238731f4433a42028d95c77893c
 
 PODFILE CHECKSUM: 40b3d892218f5282302711fd5815e53c97476e73
 

--- a/ios/Classes/Extensions/ReaderExtensions.swift
+++ b/ios/Classes/Extensions/ReaderExtensions.swift
@@ -193,3 +193,21 @@ extension ReaderChange {
         }
     }
 }
+
+extension ReaderSettings {
+  func toMap() -> NSDictionary {
+    return [
+      "isReducedChargingModeEnabled" : reducedChargingModeEnabled,
+      "preferredFirmwareUpdateTime" : preferredFirmwareUpdateTime?.toMap() ?? NSNull(),
+    ]
+  }
+}
+
+extension TimeOfDay {
+  func toMap() -> NSDictionary {
+    return [
+      "hour" : hour,
+      "minute" : minute,
+    ]
+  }
+}

--- a/ios/Classes/Modules/ReaderModule.swift
+++ b/ios/Classes/Modules/ReaderModule.swift
@@ -200,6 +200,11 @@ public class ReaderModule {
             }
         }
     }
+
+    public static func readerSettings(result: @escaping FlutterResult) {
+        let settings = MobilePaymentsSDK.shared.readerManager.readerSettings
+        result(settings.toMap())
+    }
 }
 
 class ReaderPairingDelegateImpl: ReaderPairingDelegate {

--- a/ios/Classes/Modules/SettingsModule.swift
+++ b/ios/Classes/Modules/SettingsModule.swift
@@ -64,4 +64,12 @@ public class SettingsModule {
         settingsManager.updateTrackingConsent(withGranted: granted)
         result(true)
     }
+
+    public static func closeSettings(result: @escaping FlutterResult) {
+        result(settingsManager.dismissSettings())
+    }
+    
+    public static func isShowingSettings(result: @escaping FlutterResult) {
+        result(settingsManager.isSettingsPresented)
+    }
 }

--- a/ios/Classes/SquareMobilePaymentsSdkPlugin.swift
+++ b/ios/Classes/SquareMobilePaymentsSdkPlugin.swift
@@ -128,7 +128,12 @@ public class SquareMobilePaymentsSdkPlugin: NSObject, FlutterPlugin, FlutterStre
       ReaderModule.pairReader(result: result)
     case "stopPairing":
       ReaderModule.stopPairing(result: result)
-
+    case "readerSettings":
+      ReaderModule.readerSettings(result: result)
+    case "closeSettings":
+      SettingsModule.closeSettings(result: result)
+    case "isShowingSettings":
+      SettingsModule.isShowingSettings(result: result)
     default:
       result(FlutterMethodNotImplemented)
     }

--- a/ios/square_mobile_payments_sdk.podspec
+++ b/ios/square_mobile_payments_sdk.podspec
@@ -17,8 +17,8 @@ Allows developers to take in-person payments using Square hardware.
   s.dependency 'Flutter'
   s.platform = :ios, '16.0'
 
-  s.dependency "SquareMobilePaymentsSDK", "~> 2.4.0"
-  s.dependency "MockReaderUI", "~> 2.4.0"
+  s.dependency "SquareMobilePaymentsSDK", "~> 2.5.0"
+  s.dependency "MockReaderUI", "~> 2.5.0"
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/lib/square_mobile_payments_sdk_method_channel.dart
+++ b/lib/square_mobile_payments_sdk_method_channel.dart
@@ -28,8 +28,7 @@ class MethodChannelSquareMobilePaymentsSdk
           for (var callback in _readerCallbacks.values) {
             final payload = event["payload"];
             if (payload == null) continue;
-            final changeEvent =
-                ReaderChangedEvent.fromJson(castToMap(payload));
+            final changeEvent = ReaderChangedEvent.fromJson(castToMap(payload));
             callback(changeEvent);
           }
         default:
@@ -238,9 +237,7 @@ class MethodChannelSquareMobilePaymentsSdk
       if (result == null) {
         throw getChannelStateError("getPayments()", "returned null");
       }
-      return result
-          .map((e) => OfflinePayment.fromJson(castToMap(e)))
-          .toList();
+      return result.map((e) => OfflinePayment.fromJson(castToMap(e))).toList();
     } on PlatformException catch (e) {
       throw OfflinePaymentQueueError(e.code, e.message, e.details);
     }
@@ -303,7 +300,8 @@ class MethodChannelSquareMobilePaymentsSdk
 
   @override
   Future<String> getTrackingConsentState() async {
-    final state = await methodChannel.invokeMethod<String>('getTrackingConsentState');
+    final state =
+        await methodChannel.invokeMethod<String>('getTrackingConsentState');
     if (state == null) {
       throw getChannelStateError("getTrackingConsentState()", "returned null");
     }
@@ -330,6 +328,24 @@ class MethodChannelSquareMobilePaymentsSdk
     _readerCallbacks.putIfAbsent(refId, () => callback);
     return ReaderCallbackReference(
         refId, () => removeReaderChangedCallback(refId));
+  }
+
+  @override
+  Future<ReaderSettings> readerSettings() async {
+    final result = await methodChannel.invokeMethod<Map>('readerSettings');
+    return ReaderSettings.fromJson(castToMap(result ?? {}));
+  }
+
+  @override
+  Future<bool> closeSettings() async {
+    final result = await methodChannel.invokeMethod<bool>('closeSettings');
+    return result ?? false;
+  }
+
+  @override
+  Future<bool> isShowingSettings() async {
+    final result = await methodChannel.invokeMethod<bool>('isShowingSettings');
+    return result ?? false;
   }
 
   void _startReaderCallbackIntent() {

--- a/lib/square_mobile_payments_sdk_platform_interface.dart
+++ b/lib/square_mobile_payments_sdk_platform_interface.dart
@@ -153,10 +153,24 @@ abstract class SquareMobilePaymentsSdkPlatform extends PlatformInterface {
   }
 
   Future<String> getTrackingConsentState() {
-    throw UnimplementedError('getTrackingConsentState() has not been implemented.');
+    throw UnimplementedError(
+        'getTrackingConsentState() has not been implemented.');
   }
 
   Future<void> updateTrackingConsent({required bool granted}) {
-    throw UnimplementedError('updateTrackingConsent() has not been implemented.');
+    throw UnimplementedError(
+        'updateTrackingConsent() has not been implemented.');
+  }
+
+  Future<ReaderSettings> readerSettings() {
+    throw UnimplementedError('readerSettings() has not been implemented.');
+  }
+
+  Future<bool> isShowingSettings() {
+    throw UnimplementedError('isShowingSettings() has not been implemented.');
+  }
+
+  Future<bool> closeSettings() {
+    throw UnimplementedError('closeSettings() has not been implemented.');
   }
 }

--- a/lib/src/managers/reader_manager.dart
+++ b/lib/src/managers/reader_manager.dart
@@ -36,6 +36,10 @@ class ReaderManager {
     return SquareMobilePaymentsSdkPlatform.instance.isPairingInProgress();
   }
 
+  Future<ReaderSettings> readerSettings() async {
+    return SquareMobilePaymentsSdkPlatform.instance.readerSettings();
+  }
+
   ReaderCallbackReference setReaderChangedCallback(
       FutureOr<void> Function(ReaderChangedEvent event) callback) {
     return SquareMobilePaymentsSdkPlatform.instance

--- a/lib/src/managers/settings_manager.dart
+++ b/lib/src/managers/settings_manager.dart
@@ -32,6 +32,13 @@ class SettingsManager {
         .updateTrackingConsent(granted: granted);
   }
 
+  Future<bool> closeSettings() {
+    return SquareMobilePaymentsSdkPlatform.instance.closeSettings();
+  }
+
+  Future<bool> isShowingSettings() {
+    return SquareMobilePaymentsSdkPlatform.instance.isShowingSettings();
+  }
 
   final PaymentSettings paymentSettings = _PaymentSettings();
 }

--- a/lib/src/models/errors.dart
+++ b/lib/src/models/errors.dart
@@ -21,7 +21,8 @@ enum AuthorizationErrorCode {
   unexpected,
   noNetwork,
   unsupportedCountry,
-  usageError
+  usageError,
+  obsoleteSdk
 }
 
 enum MockReaderUIErrorCode {
@@ -62,7 +63,8 @@ enum PaymentErrorCode {
   deviceClockSkewed,
   usageError,
   consentNotProvided,
-  unknown
+  unknown,
+  obsoleteSdk
 }
 
 enum OfflinePaymentQueueErrorCode {

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -101,7 +101,7 @@ class ReaderBatteryStatus with _$ReaderBatteryStatus {
 }
 
 @freezed
-class ReaderStatusInfo with _$ReaderStatusInfo{
+class ReaderStatusInfo with _$ReaderStatusInfo {
   const factory ReaderStatusInfo({
     required ReaderStatusInfoStatus status,
     ReaderStatusInfoUnavailableReason? unavailableReason,
@@ -190,7 +190,7 @@ class PaymentParameters with _$PaymentParameters {
     DelayAction? delayAction,
     num? delayDuration,
     required num processingMode,
-    required String paymentAttemptId, 
+    required String paymentAttemptId,
     String? locationId,
     String? note,
     String? orderId,
@@ -199,7 +199,7 @@ class PaymentParameters with _$PaymentParameters {
     Money? tipMoney,
   }) = _PaymentParameters;
 
-  /// ⚠️ Deprecated constructor 
+  /// ⚠️ Deprecated constructor
   @Deprecated('Use the constructor with paymentAttemptId instead.')
   @FreezedUnionValue('legacy')
   const factory PaymentParameters.legacy({
@@ -211,7 +211,7 @@ class PaymentParameters with _$PaymentParameters {
     DelayAction? delayAction,
     num? delayDuration,
     required num processingMode,
-    required String idempotencyKey, 
+    required String idempotencyKey,
     String? locationId,
     String? note,
     String? orderId,
@@ -312,4 +312,21 @@ class PairingHandle {
   factory PairingHandle(Future<StopResult> Function() stop) {
     return PairingHandle._(stop);
   }
+}
+
+@freezed
+class TimeOfDay with _$TimeOfDay {
+  const factory TimeOfDay({required int hour, required int minute}) =
+      _TimeOfDay;
+  factory TimeOfDay.fromJson(Map<String, Object?> json) =>
+      _$TimeOfDayFromJson(json);
+}
+
+@freezed
+class ReaderSettings with _$ReaderSettings {
+  const factory ReaderSettings(
+      {required bool isReducedChargingModeEnabled,
+      TimeOfDay? preferredFirmwareUpdateTime}) = _ReaderSettings;
+  factory ReaderSettings.fromJson(Map<String, Object?> json) =>
+      _$ReaderSettingsFromJson(json);
 }

--- a/lib/src/models/models.freezed.dart
+++ b/lib/src/models/models.freezed.dart
@@ -6050,3 +6050,392 @@ abstract class _ReaderChangedEvent implements ReaderChangedEvent {
   _$$ReaderChangedEventImplCopyWith<_$ReaderChangedEventImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
+
+TimeOfDay _$TimeOfDayFromJson(Map<String, dynamic> json) {
+  return _TimeOfDay.fromJson(json);
+}
+
+/// @nodoc
+mixin _$TimeOfDay {
+  int get hour => throw _privateConstructorUsedError;
+  int get minute => throw _privateConstructorUsedError;
+
+  /// Serializes this TimeOfDay to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of TimeOfDay
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $TimeOfDayCopyWith<TimeOfDay> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TimeOfDayCopyWith<$Res> {
+  factory $TimeOfDayCopyWith(TimeOfDay value, $Res Function(TimeOfDay) then) =
+      _$TimeOfDayCopyWithImpl<$Res, TimeOfDay>;
+  @useResult
+  $Res call({int hour, int minute});
+}
+
+/// @nodoc
+class _$TimeOfDayCopyWithImpl<$Res, $Val extends TimeOfDay>
+    implements $TimeOfDayCopyWith<$Res> {
+  _$TimeOfDayCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of TimeOfDay
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? hour = null,
+    Object? minute = null,
+  }) {
+    return _then(_value.copyWith(
+      hour: null == hour
+          ? _value.hour
+          : hour // ignore: cast_nullable_to_non_nullable
+              as int,
+      minute: null == minute
+          ? _value.minute
+          : minute // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$TimeOfDayImplCopyWith<$Res>
+    implements $TimeOfDayCopyWith<$Res> {
+  factory _$$TimeOfDayImplCopyWith(
+          _$TimeOfDayImpl value, $Res Function(_$TimeOfDayImpl) then) =
+      __$$TimeOfDayImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int hour, int minute});
+}
+
+/// @nodoc
+class __$$TimeOfDayImplCopyWithImpl<$Res>
+    extends _$TimeOfDayCopyWithImpl<$Res, _$TimeOfDayImpl>
+    implements _$$TimeOfDayImplCopyWith<$Res> {
+  __$$TimeOfDayImplCopyWithImpl(
+      _$TimeOfDayImpl _value, $Res Function(_$TimeOfDayImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of TimeOfDay
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? hour = null,
+    Object? minute = null,
+  }) {
+    return _then(_$TimeOfDayImpl(
+      hour: null == hour
+          ? _value.hour
+          : hour // ignore: cast_nullable_to_non_nullable
+              as int,
+      minute: null == minute
+          ? _value.minute
+          : minute // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$TimeOfDayImpl with DiagnosticableTreeMixin implements _TimeOfDay {
+  const _$TimeOfDayImpl({required this.hour, required this.minute});
+
+  factory _$TimeOfDayImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TimeOfDayImplFromJson(json);
+
+  @override
+  final int hour;
+  @override
+  final int minute;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'TimeOfDay(hour: $hour, minute: $minute)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'TimeOfDay'))
+      ..add(DiagnosticsProperty('hour', hour))
+      ..add(DiagnosticsProperty('minute', minute));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TimeOfDayImpl &&
+            (identical(other.hour, hour) || other.hour == hour) &&
+            (identical(other.minute, minute) || other.minute == minute));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, hour, minute);
+
+  /// Create a copy of TimeOfDay
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TimeOfDayImplCopyWith<_$TimeOfDayImpl> get copyWith =>
+      __$$TimeOfDayImplCopyWithImpl<_$TimeOfDayImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TimeOfDayImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _TimeOfDay implements TimeOfDay {
+  const factory _TimeOfDay(
+      {required final int hour, required final int minute}) = _$TimeOfDayImpl;
+
+  factory _TimeOfDay.fromJson(Map<String, dynamic> json) =
+      _$TimeOfDayImpl.fromJson;
+
+  @override
+  int get hour;
+  @override
+  int get minute;
+
+  /// Create a copy of TimeOfDay
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TimeOfDayImplCopyWith<_$TimeOfDayImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+ReaderSettings _$ReaderSettingsFromJson(Map<String, dynamic> json) {
+  return _ReaderSettings.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ReaderSettings {
+  bool get isReducedChargingModeEnabled => throw _privateConstructorUsedError;
+  TimeOfDay? get preferredFirmwareUpdateTime =>
+      throw _privateConstructorUsedError;
+
+  /// Serializes this ReaderSettings to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ReaderSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ReaderSettingsCopyWith<ReaderSettings> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReaderSettingsCopyWith<$Res> {
+  factory $ReaderSettingsCopyWith(
+          ReaderSettings value, $Res Function(ReaderSettings) then) =
+      _$ReaderSettingsCopyWithImpl<$Res, ReaderSettings>;
+  @useResult
+  $Res call(
+      {bool isReducedChargingModeEnabled,
+      TimeOfDay? preferredFirmwareUpdateTime});
+
+  $TimeOfDayCopyWith<$Res>? get preferredFirmwareUpdateTime;
+}
+
+/// @nodoc
+class _$ReaderSettingsCopyWithImpl<$Res, $Val extends ReaderSettings>
+    implements $ReaderSettingsCopyWith<$Res> {
+  _$ReaderSettingsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ReaderSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isReducedChargingModeEnabled = null,
+    Object? preferredFirmwareUpdateTime = freezed,
+  }) {
+    return _then(_value.copyWith(
+      isReducedChargingModeEnabled: null == isReducedChargingModeEnabled
+          ? _value.isReducedChargingModeEnabled
+          : isReducedChargingModeEnabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+      preferredFirmwareUpdateTime: freezed == preferredFirmwareUpdateTime
+          ? _value.preferredFirmwareUpdateTime
+          : preferredFirmwareUpdateTime // ignore: cast_nullable_to_non_nullable
+              as TimeOfDay?,
+    ) as $Val);
+  }
+
+  /// Create a copy of ReaderSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $TimeOfDayCopyWith<$Res>? get preferredFirmwareUpdateTime {
+    if (_value.preferredFirmwareUpdateTime == null) {
+      return null;
+    }
+
+    return $TimeOfDayCopyWith<$Res>(_value.preferredFirmwareUpdateTime!,
+        (value) {
+      return _then(_value.copyWith(preferredFirmwareUpdateTime: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ReaderSettingsImplCopyWith<$Res>
+    implements $ReaderSettingsCopyWith<$Res> {
+  factory _$$ReaderSettingsImplCopyWith(_$ReaderSettingsImpl value,
+          $Res Function(_$ReaderSettingsImpl) then) =
+      __$$ReaderSettingsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {bool isReducedChargingModeEnabled,
+      TimeOfDay? preferredFirmwareUpdateTime});
+
+  @override
+  $TimeOfDayCopyWith<$Res>? get preferredFirmwareUpdateTime;
+}
+
+/// @nodoc
+class __$$ReaderSettingsImplCopyWithImpl<$Res>
+    extends _$ReaderSettingsCopyWithImpl<$Res, _$ReaderSettingsImpl>
+    implements _$$ReaderSettingsImplCopyWith<$Res> {
+  __$$ReaderSettingsImplCopyWithImpl(
+      _$ReaderSettingsImpl _value, $Res Function(_$ReaderSettingsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ReaderSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isReducedChargingModeEnabled = null,
+    Object? preferredFirmwareUpdateTime = freezed,
+  }) {
+    return _then(_$ReaderSettingsImpl(
+      isReducedChargingModeEnabled: null == isReducedChargingModeEnabled
+          ? _value.isReducedChargingModeEnabled
+          : isReducedChargingModeEnabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+      preferredFirmwareUpdateTime: freezed == preferredFirmwareUpdateTime
+          ? _value.preferredFirmwareUpdateTime
+          : preferredFirmwareUpdateTime // ignore: cast_nullable_to_non_nullable
+              as TimeOfDay?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ReaderSettingsImpl
+    with DiagnosticableTreeMixin
+    implements _ReaderSettings {
+  const _$ReaderSettingsImpl(
+      {required this.isReducedChargingModeEnabled,
+      this.preferredFirmwareUpdateTime});
+
+  factory _$ReaderSettingsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ReaderSettingsImplFromJson(json);
+
+  @override
+  final bool isReducedChargingModeEnabled;
+  @override
+  final TimeOfDay? preferredFirmwareUpdateTime;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'ReaderSettings(isReducedChargingModeEnabled: $isReducedChargingModeEnabled, preferredFirmwareUpdateTime: $preferredFirmwareUpdateTime)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'ReaderSettings'))
+      ..add(DiagnosticsProperty(
+          'isReducedChargingModeEnabled', isReducedChargingModeEnabled))
+      ..add(DiagnosticsProperty(
+          'preferredFirmwareUpdateTime', preferredFirmwareUpdateTime));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReaderSettingsImpl &&
+            (identical(other.isReducedChargingModeEnabled,
+                    isReducedChargingModeEnabled) ||
+                other.isReducedChargingModeEnabled ==
+                    isReducedChargingModeEnabled) &&
+            (identical(other.preferredFirmwareUpdateTime,
+                    preferredFirmwareUpdateTime) ||
+                other.preferredFirmwareUpdateTime ==
+                    preferredFirmwareUpdateTime));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, isReducedChargingModeEnabled, preferredFirmwareUpdateTime);
+
+  /// Create a copy of ReaderSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReaderSettingsImplCopyWith<_$ReaderSettingsImpl> get copyWith =>
+      __$$ReaderSettingsImplCopyWithImpl<_$ReaderSettingsImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ReaderSettingsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ReaderSettings implements ReaderSettings {
+  const factory _ReaderSettings(
+      {required final bool isReducedChargingModeEnabled,
+      final TimeOfDay? preferredFirmwareUpdateTime}) = _$ReaderSettingsImpl;
+
+  factory _ReaderSettings.fromJson(Map<String, dynamic> json) =
+      _$ReaderSettingsImpl.fromJson;
+
+  @override
+  bool get isReducedChargingModeEnabled;
+  @override
+  TimeOfDay? get preferredFirmwareUpdateTime;
+
+  /// Create a copy of ReaderSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ReaderSettingsImplCopyWith<_$ReaderSettingsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/models/models.g.dart
+++ b/lib/src/models/models.g.dart
@@ -653,3 +653,32 @@ const _$ReaderChangeEnumMap = {
   ReaderChange.batteryCharging: 'batteryCharging',
   ReaderChange.firmwareProgress: 'firmwareProgress',
 };
+
+_$TimeOfDayImpl _$$TimeOfDayImplFromJson(Map<String, dynamic> json) =>
+    _$TimeOfDayImpl(
+      hour: (json['hour'] as num).toInt(),
+      minute: (json['minute'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$TimeOfDayImplToJson(_$TimeOfDayImpl instance) =>
+    <String, dynamic>{
+      'hour': instance.hour,
+      'minute': instance.minute,
+    };
+
+_$ReaderSettingsImpl _$$ReaderSettingsImplFromJson(Map<String, dynamic> json) =>
+    _$ReaderSettingsImpl(
+      isReducedChargingModeEnabled:
+          json['isReducedChargingModeEnabled'] as bool,
+      preferredFirmwareUpdateTime: json['preferredFirmwareUpdateTime'] == null
+          ? null
+          : TimeOfDay.fromJson(
+              json['preferredFirmwareUpdateTime'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$ReaderSettingsImplToJson(
+        _$ReaderSettingsImpl instance) =>
+    <String, dynamic>{
+      'isReducedChargingModeEnabled': instance.isReducedChargingModeEnabled,
+      'preferredFirmwareUpdateTime': instance.preferredFirmwareUpdateTime,
+    };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_mobile_payments_sdk
 description: "Square Mobile Payments SDK. Allows developers to take in-person payments using Square hardware."
-version: 2026.2.4
+version: 2026.3.1
 homepage: https://github.com/square/mobile-payments-sdk-flutter
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,29 @@ dev_dependencies:
   build_runner: ^2.4.13
   freezed: ^2.5.7
   json_serializable: ^6.9.0
+  integration_test:
+    sdk: flutter
 
+targets:
+  $default:
+    sources:
+      exclude:
+        - example/**
+        - test/**
+      include:
+        - lib/src/models/models.dart
+    builders:
+      freezed:
+        generate_for:
+          include:
+            - lib/src/models/models.dart
+      json_serializable:
+        generate_for:
+          include:
+            - lib/src/models/models.dart
+        options:
+          explicit_to_json: true
+          
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
@@ -75,13 +97,3 @@ flutter:
   #
   # For details regarding fonts in packages, see
   # https://flutter.dev/to/font-from-package
-
-targets:
-  $default:
-    sources:
-        exclude:
-          - example/**
-    builders:
-      json_serializable:
-        options:
-          explicit_to_json: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_mobile_payments_sdk
 description: "Square Mobile Payments SDK. Allows developers to take in-person payments using Square hardware."
-version: 2026.3.1
+version: 2026.5.1
 homepage: https://github.com/square/mobile-payments-sdk-flutter
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,8 +21,6 @@ dev_dependencies:
   build_runner: ^2.4.13
   freezed: ^2.5.7
   json_serializable: ^6.9.0
-  integration_test:
-    sdk: flutter
 
 targets:
   $default:


### PR DESCRIPTION
Upgrade native SDKs: Android 2.5.0, iOS: 2.5.0
- Updated Android and iOS plugin modules for reader and settings flows.
- Updated Flutter platform interface and method channel mappings.
- Regenerated model serialization/freezed files for the 2.5.0 SDK changes.
