### PR TITLE
add card details

### DIFF
--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/PaymentExtension.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/PaymentExtension.kt
@@ -63,6 +63,24 @@ fun Card.Brand.toBrandName(): String {
   }
 }
 
+fun Card.CoBrand.toCoBrandName() : String {
+  return when (this) {
+    Card.CoBrand.AFTERPAY -> "afterpay"
+    Card.CoBrand.CLEARPAY -> "clearpay"
+    Card.CoBrand.NONE -> "none"
+    Card.CoBrand.UNKNOWN -> "unknown"
+  }
+}
+
+fun CardPaymentDetails.Status.toStatusName(): String {
+  return when (this) {
+    CardPaymentDetails.Status.AUTHORIZED -> "authorized"
+    CardPaymentDetails.Status.CAPTURED -> "captured"
+    CardPaymentDetails.Status.VOIDED -> "voided"
+    CardPaymentDetails.Status.FAILED -> "failed"
+  }
+}
+
 fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
     return mapOf(
       "createdAt" to createdAt.toISO8601String(),
@@ -74,7 +92,8 @@ fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
       "orderId" to orderId,
       "referenceId" to referenceId,
       "sourceType" to sourceType.toName(), 
-      "cashDetails" to cashDetails?.toCashDetailsMap(), 
+      "cashDetails" to cashDetails?.toCashDetailsMap(),
+      "cardDetails" to cardDetails?.toOfflineDetailsMap(),
       "externalDetails" to externalDetails?.toExternalDetailsMap(),
       "uploadedAt" to uploadedAt?.toISO8601String(),
       "localId" to localId,
@@ -145,8 +164,8 @@ fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
 
   fun Card.toCardMap(): Map<String, Any?> {
     return mapOf(
-      "brand" to brand.name,
-      "coBrand" to cardCoBrand.name,
+      "brand" to brand.toBrandName(),
+      "coBrand" to cardCoBrand.toCoBrandName(),
       "lastFourDigits" to lastFourDigits,
       "expirationMonth" to expirationMonth,
       "expirationYear" to expirationYear,
@@ -166,11 +185,11 @@ fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
 
   fun CardPaymentDetails.OnlineCardPaymentDetails.toOnlineDetailsMap(): Map<String, Any?> {
     return mapOf(
-      "status" to status.name,
+      "status" to status.toStatusName(),
       "card" to card.toCardMap(),
-      "entryMethod" to entryMethod.name,
+      "entryMethod" to entryMethod.toEntryMethodName(),
       "authorizationCode" to authorizationCode,
-      "applicationId" to applicationId,
+      "applicationIdentifier" to applicationId,
       "applicationName" to applicationName,
       "verificationMethod" to verificationMethod?.name,
       "verificationResults" to verificationResults?.name,

--- a/ios/Classes/Extensions/PaymentExtension.swift
+++ b/ios/Classes/Extensions/PaymentExtension.swift
@@ -47,6 +47,7 @@ extension OnlinePayment {
             "locationId" : locationID,
             "orderId": orderID,
             "referenceId" : referenceID,
+            "cardDetails": cardDetails?.toMap(),
             "sourceType" : sourceType.getName(),
             "tipMoney": tipMoney?.toMap(),
             "totalMoney": totalMoney.toMap(),
@@ -55,6 +56,54 @@ extension OnlinePayment {
     }
 }
 
+extension CardPaymentDetails {
+    public func toMap() -> [String: Any?] {
+        return [
+            "applicationIdentifier": applicationIdentifier,
+            "applicationName": applicationName,
+            "authorizationCode": authResultCode,
+            "card": card?.toMap(),
+            "entryMethod": entryMethod.getName(),
+            "status": status.getName(),
+        ]
+    }
+}
+
+extension CardPaymentStatus {
+    func getName() -> String {
+        switch self {
+            case .authorized: return "authorized"
+            case .captured: return "captured"
+            case .voided: return "voided"
+            case .failed: return "failed"
+            default: return "unknown"
+        }
+    }
+}
+
+extension CardCoBrand {
+    func getName() -> String {
+        switch self {
+            case .afterpay: return "afterpay"
+            case .none: return "none"
+            default: return "unknown"
+        }
+    }
+}
+
+extension Card {
+    public func toMap() -> [String: Any?] {
+        return [
+            "brand": cardBrand.getName(),
+            "cardholderName": cardholderName,
+            "coBrand": coBrand.getName(),
+            "expirationMonth": expMonth,
+            "expirationYear": expYear,
+            "id": id,
+            "lastFourDigits": last4,
+        ]
+    }
+}
 
 extension OfflineStatus {
     public func getName() -> String {

--- a/ios/Classes/Modules/PaymentModule.swift
+++ b/ios/Classes/Modules/PaymentModule.swift
@@ -95,7 +95,7 @@ public class PaymentModule: PaymentManagerDelegate {
         if let onlinePayment = payment as? OnlinePayment {
             delegateResult?(onlinePayment.toMap())
         } else if let offlinePayment = payment as? OfflinePayment {
-            delegateResult?(nil)
+            delegateResult?(offlinePayment.toMap())
         } else {
             delegateResult?(nil)
         }

--- a/lib/src/models/enums.dart
+++ b/lib/src/models/enums.dart
@@ -26,18 +26,12 @@ enum CardBrand {
   ebt,
   jcb,
   chinaUnionPay,
-  unionPayInternational, //unionPayInternational != chinaUnionPay ?
   squareGiftCard,
-  alipay,
-  cashApp,
   eftpos,
   felica,
   interac,
   squareCapitalCard,
-  suica,
-  id,
-  quicpay,
-  unknown,
+  unknown
 }
 
 enum CardCoBrand {
@@ -157,7 +151,6 @@ enum ReaderStatusInfoStatus {
   ready,
 }
 
-
 enum ReaderStatusInfoUnavailableReason {
   internalError,
   bluetoothDisabled,
@@ -187,7 +180,6 @@ enum ReaderStatusInfoUnavailableReason {
   deviceDeveloperMode,
   disabled
 }
-
 
 enum ReaderModel {
   contactlessAndChip,

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -35,13 +35,13 @@ class Money with _$Money {
 @freezed
 class Card with _$Card {
   const factory Card({
-    required CardBrand brand,
+    @JsonKey(unknownEnumValue: CardBrand.unknown) required CardBrand brand,
     String? cardholderName,
-    required CardCoBrand coBrand,
+    @JsonKey(unknownEnumValue: CardCoBrand.unknown) CardCoBrand? coBrand,
     @Default(0) num expirationMonth,
     @Default(0) num expirationYear,
     String? id,
-    required String lastFourDigits,
+    String? lastFourDigits,
   }) = _Card;
 
   factory Card.fromJson(Map<String, Object?> json) => _$CardFromJson(json);
@@ -63,12 +63,14 @@ class OfflineCard with _$OfflineCard {
 @freezed
 class CardPaymentDetails with _$CardPaymentDetails {
   const factory CardPaymentDetails({
-    required String applicationIdentifier,
-    required String applicationName,
-    required String authorizationCode,
-    required Card card,
+    String? applicationIdentifier,
+    String? applicationName,
+    String? authorizationCode,
+    Card? card,
+    @JsonKey(unknownEnumValue: EntryMethod.unknown)
     required EntryMethod entryMethod,
-    required CardPaymentStatus status,
+    @JsonKey(unknownEnumValue: CardPaymentStatus.unknown)
+    CardPaymentStatus? status,
   }) = _CardPaymentDetails;
 
   factory CardPaymentDetails.fromJson(Map<String, Object?> json) =>
@@ -162,6 +164,7 @@ class Payment with _$Payment {
   const factory Payment({
     required Money amountMoney,
     Money? appFeeMoney,
+    CardPaymentDetails? cardDetails,
     required DateTime createdAt,
     String? id,
     String? locationId,

--- a/lib/src/models/models.freezed.dart
+++ b/lib/src/models/models.freezed.dart
@@ -388,13 +388,15 @@ Card _$CardFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$Card {
+  @JsonKey(unknownEnumValue: CardBrand.unknown)
   CardBrand get brand => throw _privateConstructorUsedError;
   String? get cardholderName => throw _privateConstructorUsedError;
-  CardCoBrand get coBrand => throw _privateConstructorUsedError;
+  @JsonKey(unknownEnumValue: CardCoBrand.unknown)
+  CardCoBrand? get coBrand => throw _privateConstructorUsedError;
   num get expirationMonth => throw _privateConstructorUsedError;
   num get expirationYear => throw _privateConstructorUsedError;
   String? get id => throw _privateConstructorUsedError;
-  String get lastFourDigits => throw _privateConstructorUsedError;
+  String? get lastFourDigits => throw _privateConstructorUsedError;
 
   /// Serializes this Card to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -411,13 +413,13 @@ abstract class $CardCopyWith<$Res> {
       _$CardCopyWithImpl<$Res, Card>;
   @useResult
   $Res call(
-      {CardBrand brand,
+      {@JsonKey(unknownEnumValue: CardBrand.unknown) CardBrand brand,
       String? cardholderName,
-      CardCoBrand coBrand,
+      @JsonKey(unknownEnumValue: CardCoBrand.unknown) CardCoBrand? coBrand,
       num expirationMonth,
       num expirationYear,
       String? id,
-      String lastFourDigits});
+      String? lastFourDigits});
 }
 
 /// @nodoc
@@ -437,11 +439,11 @@ class _$CardCopyWithImpl<$Res, $Val extends Card>
   $Res call({
     Object? brand = null,
     Object? cardholderName = freezed,
-    Object? coBrand = null,
+    Object? coBrand = freezed,
     Object? expirationMonth = null,
     Object? expirationYear = null,
     Object? id = freezed,
-    Object? lastFourDigits = null,
+    Object? lastFourDigits = freezed,
   }) {
     return _then(_value.copyWith(
       brand: null == brand
@@ -452,10 +454,10 @@ class _$CardCopyWithImpl<$Res, $Val extends Card>
           ? _value.cardholderName
           : cardholderName // ignore: cast_nullable_to_non_nullable
               as String?,
-      coBrand: null == coBrand
+      coBrand: freezed == coBrand
           ? _value.coBrand
           : coBrand // ignore: cast_nullable_to_non_nullable
-              as CardCoBrand,
+              as CardCoBrand?,
       expirationMonth: null == expirationMonth
           ? _value.expirationMonth
           : expirationMonth // ignore: cast_nullable_to_non_nullable
@@ -468,10 +470,10 @@ class _$CardCopyWithImpl<$Res, $Val extends Card>
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String?,
-      lastFourDigits: null == lastFourDigits
+      lastFourDigits: freezed == lastFourDigits
           ? _value.lastFourDigits
           : lastFourDigits // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
     ) as $Val);
   }
 }
@@ -484,13 +486,13 @@ abstract class _$$CardImplCopyWith<$Res> implements $CardCopyWith<$Res> {
   @override
   @useResult
   $Res call(
-      {CardBrand brand,
+      {@JsonKey(unknownEnumValue: CardBrand.unknown) CardBrand brand,
       String? cardholderName,
-      CardCoBrand coBrand,
+      @JsonKey(unknownEnumValue: CardCoBrand.unknown) CardCoBrand? coBrand,
       num expirationMonth,
       num expirationYear,
       String? id,
-      String lastFourDigits});
+      String? lastFourDigits});
 }
 
 /// @nodoc
@@ -507,11 +509,11 @@ class __$$CardImplCopyWithImpl<$Res>
   $Res call({
     Object? brand = null,
     Object? cardholderName = freezed,
-    Object? coBrand = null,
+    Object? coBrand = freezed,
     Object? expirationMonth = null,
     Object? expirationYear = null,
     Object? id = freezed,
-    Object? lastFourDigits = null,
+    Object? lastFourDigits = freezed,
   }) {
     return _then(_$CardImpl(
       brand: null == brand
@@ -522,10 +524,10 @@ class __$$CardImplCopyWithImpl<$Res>
           ? _value.cardholderName
           : cardholderName // ignore: cast_nullable_to_non_nullable
               as String?,
-      coBrand: null == coBrand
+      coBrand: freezed == coBrand
           ? _value.coBrand
           : coBrand // ignore: cast_nullable_to_non_nullable
-              as CardCoBrand,
+              as CardCoBrand?,
       expirationMonth: null == expirationMonth
           ? _value.expirationMonth
           : expirationMonth // ignore: cast_nullable_to_non_nullable
@@ -538,10 +540,10 @@ class __$$CardImplCopyWithImpl<$Res>
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String?,
-      lastFourDigits: null == lastFourDigits
+      lastFourDigits: freezed == lastFourDigits
           ? _value.lastFourDigits
           : lastFourDigits // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
     ));
   }
 }
@@ -550,23 +552,25 @@ class __$$CardImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$CardImpl with DiagnosticableTreeMixin implements _Card {
   const _$CardImpl(
-      {required this.brand,
+      {@JsonKey(unknownEnumValue: CardBrand.unknown) required this.brand,
       this.cardholderName,
-      required this.coBrand,
+      @JsonKey(unknownEnumValue: CardCoBrand.unknown) this.coBrand,
       this.expirationMonth = 0,
       this.expirationYear = 0,
       this.id,
-      required this.lastFourDigits});
+      this.lastFourDigits});
 
   factory _$CardImpl.fromJson(Map<String, dynamic> json) =>
       _$$CardImplFromJson(json);
 
   @override
+  @JsonKey(unknownEnumValue: CardBrand.unknown)
   final CardBrand brand;
   @override
   final String? cardholderName;
   @override
-  final CardCoBrand coBrand;
+  @JsonKey(unknownEnumValue: CardCoBrand.unknown)
+  final CardCoBrand? coBrand;
   @override
   @JsonKey()
   final num expirationMonth;
@@ -576,7 +580,7 @@ class _$CardImpl with DiagnosticableTreeMixin implements _Card {
   @override
   final String? id;
   @override
-  final String lastFourDigits;
+  final String? lastFourDigits;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
@@ -638,22 +642,26 @@ class _$CardImpl with DiagnosticableTreeMixin implements _Card {
 
 abstract class _Card implements Card {
   const factory _Card(
-      {required final CardBrand brand,
+      {@JsonKey(unknownEnumValue: CardBrand.unknown)
+      required final CardBrand brand,
       final String? cardholderName,
-      required final CardCoBrand coBrand,
+      @JsonKey(unknownEnumValue: CardCoBrand.unknown)
+      final CardCoBrand? coBrand,
       final num expirationMonth,
       final num expirationYear,
       final String? id,
-      required final String lastFourDigits}) = _$CardImpl;
+      final String? lastFourDigits}) = _$CardImpl;
 
   factory _Card.fromJson(Map<String, dynamic> json) = _$CardImpl.fromJson;
 
   @override
+  @JsonKey(unknownEnumValue: CardBrand.unknown)
   CardBrand get brand;
   @override
   String? get cardholderName;
   @override
-  CardCoBrand get coBrand;
+  @JsonKey(unknownEnumValue: CardCoBrand.unknown)
+  CardCoBrand? get coBrand;
   @override
   num get expirationMonth;
   @override
@@ -661,7 +669,7 @@ abstract class _Card implements Card {
   @override
   String? get id;
   @override
-  String get lastFourDigits;
+  String? get lastFourDigits;
 
   /// Create a copy of Card
   /// with the given fields replaced by the non-null parameter values.
@@ -901,12 +909,14 @@ CardPaymentDetails _$CardPaymentDetailsFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$CardPaymentDetails {
-  String get applicationIdentifier => throw _privateConstructorUsedError;
-  String get applicationName => throw _privateConstructorUsedError;
-  String get authorizationCode => throw _privateConstructorUsedError;
-  Card get card => throw _privateConstructorUsedError;
+  String? get applicationIdentifier => throw _privateConstructorUsedError;
+  String? get applicationName => throw _privateConstructorUsedError;
+  String? get authorizationCode => throw _privateConstructorUsedError;
+  Card? get card => throw _privateConstructorUsedError;
+  @JsonKey(unknownEnumValue: EntryMethod.unknown)
   EntryMethod get entryMethod => throw _privateConstructorUsedError;
-  CardPaymentStatus get status => throw _privateConstructorUsedError;
+  @JsonKey(unknownEnumValue: CardPaymentStatus.unknown)
+  CardPaymentStatus? get status => throw _privateConstructorUsedError;
 
   /// Serializes this CardPaymentDetails to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -925,14 +935,15 @@ abstract class $CardPaymentDetailsCopyWith<$Res> {
       _$CardPaymentDetailsCopyWithImpl<$Res, CardPaymentDetails>;
   @useResult
   $Res call(
-      {String applicationIdentifier,
-      String applicationName,
-      String authorizationCode,
-      Card card,
-      EntryMethod entryMethod,
-      CardPaymentStatus status});
+      {String? applicationIdentifier,
+      String? applicationName,
+      String? authorizationCode,
+      Card? card,
+      @JsonKey(unknownEnumValue: EntryMethod.unknown) EntryMethod entryMethod,
+      @JsonKey(unknownEnumValue: CardPaymentStatus.unknown)
+      CardPaymentStatus? status});
 
-  $CardCopyWith<$Res> get card;
+  $CardCopyWith<$Res>? get card;
 }
 
 /// @nodoc
@@ -950,38 +961,38 @@ class _$CardPaymentDetailsCopyWithImpl<$Res, $Val extends CardPaymentDetails>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? applicationIdentifier = null,
-    Object? applicationName = null,
-    Object? authorizationCode = null,
-    Object? card = null,
+    Object? applicationIdentifier = freezed,
+    Object? applicationName = freezed,
+    Object? authorizationCode = freezed,
+    Object? card = freezed,
     Object? entryMethod = null,
-    Object? status = null,
+    Object? status = freezed,
   }) {
     return _then(_value.copyWith(
-      applicationIdentifier: null == applicationIdentifier
+      applicationIdentifier: freezed == applicationIdentifier
           ? _value.applicationIdentifier
           : applicationIdentifier // ignore: cast_nullable_to_non_nullable
-              as String,
-      applicationName: null == applicationName
+              as String?,
+      applicationName: freezed == applicationName
           ? _value.applicationName
           : applicationName // ignore: cast_nullable_to_non_nullable
-              as String,
-      authorizationCode: null == authorizationCode
+              as String?,
+      authorizationCode: freezed == authorizationCode
           ? _value.authorizationCode
           : authorizationCode // ignore: cast_nullable_to_non_nullable
-              as String,
-      card: null == card
+              as String?,
+      card: freezed == card
           ? _value.card
           : card // ignore: cast_nullable_to_non_nullable
-              as Card,
+              as Card?,
       entryMethod: null == entryMethod
           ? _value.entryMethod
           : entryMethod // ignore: cast_nullable_to_non_nullable
               as EntryMethod,
-      status: null == status
+      status: freezed == status
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
-              as CardPaymentStatus,
+              as CardPaymentStatus?,
     ) as $Val);
   }
 
@@ -989,8 +1000,12 @@ class _$CardPaymentDetailsCopyWithImpl<$Res, $Val extends CardPaymentDetails>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  $CardCopyWith<$Res> get card {
-    return $CardCopyWith<$Res>(_value.card, (value) {
+  $CardCopyWith<$Res>? get card {
+    if (_value.card == null) {
+      return null;
+    }
+
+    return $CardCopyWith<$Res>(_value.card!, (value) {
       return _then(_value.copyWith(card: value) as $Val);
     });
   }
@@ -1005,15 +1020,16 @@ abstract class _$$CardPaymentDetailsImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String applicationIdentifier,
-      String applicationName,
-      String authorizationCode,
-      Card card,
-      EntryMethod entryMethod,
-      CardPaymentStatus status});
+      {String? applicationIdentifier,
+      String? applicationName,
+      String? authorizationCode,
+      Card? card,
+      @JsonKey(unknownEnumValue: EntryMethod.unknown) EntryMethod entryMethod,
+      @JsonKey(unknownEnumValue: CardPaymentStatus.unknown)
+      CardPaymentStatus? status});
 
   @override
-  $CardCopyWith<$Res> get card;
+  $CardCopyWith<$Res>? get card;
 }
 
 /// @nodoc
@@ -1029,38 +1045,38 @@ class __$$CardPaymentDetailsImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? applicationIdentifier = null,
-    Object? applicationName = null,
-    Object? authorizationCode = null,
-    Object? card = null,
+    Object? applicationIdentifier = freezed,
+    Object? applicationName = freezed,
+    Object? authorizationCode = freezed,
+    Object? card = freezed,
     Object? entryMethod = null,
-    Object? status = null,
+    Object? status = freezed,
   }) {
     return _then(_$CardPaymentDetailsImpl(
-      applicationIdentifier: null == applicationIdentifier
+      applicationIdentifier: freezed == applicationIdentifier
           ? _value.applicationIdentifier
           : applicationIdentifier // ignore: cast_nullable_to_non_nullable
-              as String,
-      applicationName: null == applicationName
+              as String?,
+      applicationName: freezed == applicationName
           ? _value.applicationName
           : applicationName // ignore: cast_nullable_to_non_nullable
-              as String,
-      authorizationCode: null == authorizationCode
+              as String?,
+      authorizationCode: freezed == authorizationCode
           ? _value.authorizationCode
           : authorizationCode // ignore: cast_nullable_to_non_nullable
-              as String,
-      card: null == card
+              as String?,
+      card: freezed == card
           ? _value.card
           : card // ignore: cast_nullable_to_non_nullable
-              as Card,
+              as Card?,
       entryMethod: null == entryMethod
           ? _value.entryMethod
           : entryMethod // ignore: cast_nullable_to_non_nullable
               as EntryMethod,
-      status: null == status
+      status: freezed == status
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
-              as CardPaymentStatus,
+              as CardPaymentStatus?,
     ));
   }
 }
@@ -1071,28 +1087,30 @@ class _$CardPaymentDetailsImpl
     with DiagnosticableTreeMixin
     implements _CardPaymentDetails {
   const _$CardPaymentDetailsImpl(
-      {required this.applicationIdentifier,
-      required this.applicationName,
-      required this.authorizationCode,
-      required this.card,
-      required this.entryMethod,
-      required this.status});
+      {this.applicationIdentifier,
+      this.applicationName,
+      this.authorizationCode,
+      this.card,
+      @JsonKey(unknownEnumValue: EntryMethod.unknown) required this.entryMethod,
+      @JsonKey(unknownEnumValue: CardPaymentStatus.unknown) this.status});
 
   factory _$CardPaymentDetailsImpl.fromJson(Map<String, dynamic> json) =>
       _$$CardPaymentDetailsImplFromJson(json);
 
   @override
-  final String applicationIdentifier;
+  final String? applicationIdentifier;
   @override
-  final String applicationName;
+  final String? applicationName;
   @override
-  final String authorizationCode;
+  final String? authorizationCode;
   @override
-  final Card card;
+  final Card? card;
   @override
+  @JsonKey(unknownEnumValue: EntryMethod.unknown)
   final EntryMethod entryMethod;
   @override
-  final CardPaymentStatus status;
+  @JsonKey(unknownEnumValue: CardPaymentStatus.unknown)
+  final CardPaymentStatus? status;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
@@ -1153,28 +1171,32 @@ class _$CardPaymentDetailsImpl
 
 abstract class _CardPaymentDetails implements CardPaymentDetails {
   const factory _CardPaymentDetails(
-      {required final String applicationIdentifier,
-      required final String applicationName,
-      required final String authorizationCode,
-      required final Card card,
+      {final String? applicationIdentifier,
+      final String? applicationName,
+      final String? authorizationCode,
+      final Card? card,
+      @JsonKey(unknownEnumValue: EntryMethod.unknown)
       required final EntryMethod entryMethod,
-      required final CardPaymentStatus status}) = _$CardPaymentDetailsImpl;
+      @JsonKey(unknownEnumValue: CardPaymentStatus.unknown)
+      final CardPaymentStatus? status}) = _$CardPaymentDetailsImpl;
 
   factory _CardPaymentDetails.fromJson(Map<String, dynamic> json) =
       _$CardPaymentDetailsImpl.fromJson;
 
   @override
-  String get applicationIdentifier;
+  String? get applicationIdentifier;
   @override
-  String get applicationName;
+  String? get applicationName;
   @override
-  String get authorizationCode;
+  String? get authorizationCode;
   @override
-  Card get card;
+  Card? get card;
   @override
+  @JsonKey(unknownEnumValue: EntryMethod.unknown)
   EntryMethod get entryMethod;
   @override
-  CardPaymentStatus get status;
+  @JsonKey(unknownEnumValue: CardPaymentStatus.unknown)
+  CardPaymentStatus? get status;
 
   /// Create a copy of CardPaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -2651,6 +2673,7 @@ Payment _$PaymentFromJson(Map<String, dynamic> json) {
 mixin _$Payment {
   Money get amountMoney => throw _privateConstructorUsedError;
   Money? get appFeeMoney => throw _privateConstructorUsedError;
+  CardPaymentDetails? get cardDetails => throw _privateConstructorUsedError;
   DateTime get createdAt => throw _privateConstructorUsedError;
   String? get id => throw _privateConstructorUsedError;
   String? get locationId => throw _privateConstructorUsedError;
@@ -2678,6 +2701,7 @@ abstract class $PaymentCopyWith<$Res> {
   $Res call(
       {Money amountMoney,
       Money? appFeeMoney,
+      CardPaymentDetails? cardDetails,
       DateTime createdAt,
       String? id,
       String? locationId,
@@ -2690,6 +2714,7 @@ abstract class $PaymentCopyWith<$Res> {
 
   $MoneyCopyWith<$Res> get amountMoney;
   $MoneyCopyWith<$Res>? get appFeeMoney;
+  $CardPaymentDetailsCopyWith<$Res>? get cardDetails;
   $MoneyCopyWith<$Res>? get tipMoney;
   $MoneyCopyWith<$Res> get totalMoney;
 }
@@ -2711,6 +2736,7 @@ class _$PaymentCopyWithImpl<$Res, $Val extends Payment>
   $Res call({
     Object? amountMoney = null,
     Object? appFeeMoney = freezed,
+    Object? cardDetails = freezed,
     Object? createdAt = null,
     Object? id = freezed,
     Object? locationId = freezed,
@@ -2730,6 +2756,10 @@ class _$PaymentCopyWithImpl<$Res, $Val extends Payment>
           ? _value.appFeeMoney
           : appFeeMoney // ignore: cast_nullable_to_non_nullable
               as Money?,
+      cardDetails: freezed == cardDetails
+          ? _value.cardDetails
+          : cardDetails // ignore: cast_nullable_to_non_nullable
+              as CardPaymentDetails?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -2797,6 +2827,20 @@ class _$PaymentCopyWithImpl<$Res, $Val extends Payment>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
+  $CardPaymentDetailsCopyWith<$Res>? get cardDetails {
+    if (_value.cardDetails == null) {
+      return null;
+    }
+
+    return $CardPaymentDetailsCopyWith<$Res>(_value.cardDetails!, (value) {
+      return _then(_value.copyWith(cardDetails: value) as $Val);
+    });
+  }
+
+  /// Create a copy of Payment
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
   $MoneyCopyWith<$Res>? get tipMoney {
     if (_value.tipMoney == null) {
       return null;
@@ -2828,6 +2872,7 @@ abstract class _$$PaymentImplCopyWith<$Res> implements $PaymentCopyWith<$Res> {
   $Res call(
       {Money amountMoney,
       Money? appFeeMoney,
+      CardPaymentDetails? cardDetails,
       DateTime createdAt,
       String? id,
       String? locationId,
@@ -2842,6 +2887,8 @@ abstract class _$$PaymentImplCopyWith<$Res> implements $PaymentCopyWith<$Res> {
   $MoneyCopyWith<$Res> get amountMoney;
   @override
   $MoneyCopyWith<$Res>? get appFeeMoney;
+  @override
+  $CardPaymentDetailsCopyWith<$Res>? get cardDetails;
   @override
   $MoneyCopyWith<$Res>? get tipMoney;
   @override
@@ -2863,6 +2910,7 @@ class __$$PaymentImplCopyWithImpl<$Res>
   $Res call({
     Object? amountMoney = null,
     Object? appFeeMoney = freezed,
+    Object? cardDetails = freezed,
     Object? createdAt = null,
     Object? id = freezed,
     Object? locationId = freezed,
@@ -2882,6 +2930,10 @@ class __$$PaymentImplCopyWithImpl<$Res>
           ? _value.appFeeMoney
           : appFeeMoney // ignore: cast_nullable_to_non_nullable
               as Money?,
+      cardDetails: freezed == cardDetails
+          ? _value.cardDetails
+          : cardDetails // ignore: cast_nullable_to_non_nullable
+              as CardPaymentDetails?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -2928,6 +2980,7 @@ class _$PaymentImpl with DiagnosticableTreeMixin implements _Payment {
   const _$PaymentImpl(
       {required this.amountMoney,
       this.appFeeMoney,
+      this.cardDetails,
       required this.createdAt,
       this.id,
       this.locationId,
@@ -2945,6 +2998,8 @@ class _$PaymentImpl with DiagnosticableTreeMixin implements _Payment {
   final Money amountMoney;
   @override
   final Money? appFeeMoney;
+  @override
+  final CardPaymentDetails? cardDetails;
   @override
   final DateTime createdAt;
   @override
@@ -2966,7 +3021,7 @@ class _$PaymentImpl with DiagnosticableTreeMixin implements _Payment {
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'Payment(amountMoney: $amountMoney, appFeeMoney: $appFeeMoney, createdAt: $createdAt, id: $id, locationId: $locationId, orderId: $orderId, referenceId: $referenceId, sourceType: $sourceType, tipMoney: $tipMoney, totalMoney: $totalMoney, updatedAt: $updatedAt)';
+    return 'Payment(amountMoney: $amountMoney, appFeeMoney: $appFeeMoney, cardDetails: $cardDetails, createdAt: $createdAt, id: $id, locationId: $locationId, orderId: $orderId, referenceId: $referenceId, sourceType: $sourceType, tipMoney: $tipMoney, totalMoney: $totalMoney, updatedAt: $updatedAt)';
   }
 
   @override
@@ -2976,6 +3031,7 @@ class _$PaymentImpl with DiagnosticableTreeMixin implements _Payment {
       ..add(DiagnosticsProperty('type', 'Payment'))
       ..add(DiagnosticsProperty('amountMoney', amountMoney))
       ..add(DiagnosticsProperty('appFeeMoney', appFeeMoney))
+      ..add(DiagnosticsProperty('cardDetails', cardDetails))
       ..add(DiagnosticsProperty('createdAt', createdAt))
       ..add(DiagnosticsProperty('id', id))
       ..add(DiagnosticsProperty('locationId', locationId))
@@ -2996,6 +3052,8 @@ class _$PaymentImpl with DiagnosticableTreeMixin implements _Payment {
                 other.amountMoney == amountMoney) &&
             (identical(other.appFeeMoney, appFeeMoney) ||
                 other.appFeeMoney == appFeeMoney) &&
+            (identical(other.cardDetails, cardDetails) ||
+                other.cardDetails == cardDetails) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.id, id) || other.id == id) &&
@@ -3020,6 +3078,7 @@ class _$PaymentImpl with DiagnosticableTreeMixin implements _Payment {
       runtimeType,
       amountMoney,
       appFeeMoney,
+      cardDetails,
       createdAt,
       id,
       locationId,
@@ -3050,6 +3109,7 @@ abstract class _Payment implements Payment {
   const factory _Payment(
       {required final Money amountMoney,
       final Money? appFeeMoney,
+      final CardPaymentDetails? cardDetails,
       required final DateTime createdAt,
       final String? id,
       final String? locationId,
@@ -3066,6 +3126,8 @@ abstract class _Payment implements Payment {
   Money get amountMoney;
   @override
   Money? get appFeeMoney;
+  @override
+  CardPaymentDetails? get cardDetails;
   @override
   DateTime get createdAt;
   @override

--- a/lib/src/models/models.g.dart
+++ b/lib/src/models/models.g.dart
@@ -41,20 +41,22 @@ Map<String, dynamic> _$$MoneyImplToJson(_$MoneyImpl instance) =>
     };
 
 _$CardImpl _$$CardImplFromJson(Map<String, dynamic> json) => _$CardImpl(
-      brand: $enumDecode(_$CardBrandEnumMap, json['brand']),
+      brand: $enumDecode(_$CardBrandEnumMap, json['brand'],
+          unknownValue: CardBrand.unknown),
       cardholderName: json['cardholderName'] as String?,
-      coBrand: $enumDecode(_$CardCoBrandEnumMap, json['coBrand']),
+      coBrand: $enumDecodeNullable(_$CardCoBrandEnumMap, json['coBrand'],
+          unknownValue: CardCoBrand.unknown),
       expirationMonth: json['expirationMonth'] as num? ?? 0,
       expirationYear: json['expirationYear'] as num? ?? 0,
       id: json['id'] as String?,
-      lastFourDigits: json['lastFourDigits'] as String,
+      lastFourDigits: json['lastFourDigits'] as String?,
     );
 
 Map<String, dynamic> _$$CardImplToJson(_$CardImpl instance) =>
     <String, dynamic>{
       'brand': _$CardBrandEnumMap[instance.brand]!,
       'cardholderName': instance.cardholderName,
-      'coBrand': _$CardCoBrandEnumMap[instance.coBrand]!,
+      'coBrand': _$CardCoBrandEnumMap[instance.coBrand],
       'expirationMonth': instance.expirationMonth,
       'expirationYear': instance.expirationYear,
       'id': instance.id,
@@ -71,17 +73,11 @@ const _$CardBrandEnumMap = {
   CardBrand.ebt: 'ebt',
   CardBrand.jcb: 'jcb',
   CardBrand.chinaUnionPay: 'chinaUnionPay',
-  CardBrand.unionPayInternational: 'unionPayInternational',
   CardBrand.squareGiftCard: 'squareGiftCard',
-  CardBrand.alipay: 'alipay',
-  CardBrand.cashApp: 'cashApp',
   CardBrand.eftpos: 'eftpos',
   CardBrand.felica: 'felica',
   CardBrand.interac: 'interac',
   CardBrand.squareCapitalCard: 'squareCapitalCard',
-  CardBrand.suica: 'suica',
-  CardBrand.id: 'id',
-  CardBrand.quicpay: 'quicpay',
   CardBrand.unknown: 'unknown',
 };
 
@@ -111,12 +107,16 @@ Map<String, dynamic> _$$OfflineCardImplToJson(_$OfflineCardImpl instance) =>
 _$CardPaymentDetailsImpl _$$CardPaymentDetailsImplFromJson(
         Map<String, dynamic> json) =>
     _$CardPaymentDetailsImpl(
-      applicationIdentifier: json['applicationIdentifier'] as String,
-      applicationName: json['applicationName'] as String,
-      authorizationCode: json['authorizationCode'] as String,
-      card: Card.fromJson(json['card'] as Map<String, dynamic>),
-      entryMethod: $enumDecode(_$EntryMethodEnumMap, json['entryMethod']),
-      status: $enumDecode(_$CardPaymentStatusEnumMap, json['status']),
+      applicationIdentifier: json['applicationIdentifier'] as String?,
+      applicationName: json['applicationName'] as String?,
+      authorizationCode: json['authorizationCode'] as String?,
+      card: json['card'] == null
+          ? null
+          : Card.fromJson(json['card'] as Map<String, dynamic>),
+      entryMethod: $enumDecode(_$EntryMethodEnumMap, json['entryMethod'],
+          unknownValue: EntryMethod.unknown),
+      status: $enumDecodeNullable(_$CardPaymentStatusEnumMap, json['status'],
+          unknownValue: CardPaymentStatus.unknown),
     );
 
 Map<String, dynamic> _$$CardPaymentDetailsImplToJson(
@@ -127,7 +127,7 @@ Map<String, dynamic> _$$CardPaymentDetailsImplToJson(
       'authorizationCode': instance.authorizationCode,
       'card': instance.card,
       'entryMethod': _$EntryMethodEnumMap[instance.entryMethod]!,
-      'status': _$CardPaymentStatusEnumMap[instance.status]!,
+      'status': _$CardPaymentStatusEnumMap[instance.status],
     };
 
 const _$EntryMethodEnumMap = {
@@ -364,6 +364,10 @@ _$PaymentImpl _$$PaymentImplFromJson(Map<String, dynamic> json) =>
       appFeeMoney: json['appFeeMoney'] == null
           ? null
           : Money.fromJson(json['appFeeMoney'] as Map<String, dynamic>),
+      cardDetails: json['cardDetails'] == null
+          ? null
+          : CardPaymentDetails.fromJson(
+              json['cardDetails'] as Map<String, dynamic>),
       createdAt: DateTime.parse(json['createdAt'] as String),
       id: json['id'] as String?,
       locationId: json['locationId'] as String?,
@@ -381,6 +385,7 @@ Map<String, dynamic> _$$PaymentImplToJson(_$PaymentImpl instance) =>
     <String, dynamic>{
       'amountMoney': instance.amountMoney,
       'appFeeMoney': instance.appFeeMoney,
+      'cardDetails': instance.cardDetails,
       'createdAt': instance.createdAt.toIso8601String(),
       'id': instance.id,
       'locationId': instance.locationId,


### PR DESCRIPTION
PaymentManager.startPayment() returned a Payment missing card metadata (brand/last4/entry method/status), forcing users to call the Payments API even though native SDKs already had that data.
	This fixes the end-to-end mapping:

Dart: add Payment.cardDetails, align nullability with native, and add unknownEnumValue handling to avoid enum decode crashes.
iOS: include cardDetails in OnlinePayment.toMap() and add toMap() helpers for CardPaymentDetails/Card.
Android: fix key applicationId → applicationIdentifier and normalize enum/string casing so Dart can decode reliably.
	Result: startPayment() now returns Payment.cardDetails when available, with no extra API call needed.