### PR TITLE
fix issue 41 add delay parameters

### DIFF
--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/mappers/PaymentMapper.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/mappers/PaymentMapper.kt
@@ -1,6 +1,7 @@
 package com.squareup.square_mobile_payments_sdk.mappers
 
 import com.squareup.sdk.mobilepayments.payment.CurrencyCode
+import com.squareup.sdk.mobilepayments.payment.DelayAction
 import com.squareup.sdk.mobilepayments.payment.Money
 import com.squareup.sdk.mobilepayments.payment.PaymentParameters
 import com.squareup.sdk.mobilepayments.payment.PromptMode
@@ -47,6 +48,17 @@ class PaymentMapper {
                     val tipCurrencyCode = CurrencyCode.valueOf(tipCurrency);
 
                     builder.tipMoney(Money(tipAmount, tipCurrencyCode))
+                }
+
+                if(paymentParameters.get("delayDuration") != null) {
+                    builder.delayDuration(paymentParameters.get("delayDuration") as? Long)
+                }
+
+                if(paymentParameters.get("delayAction") != null) {
+                    val delayActionString = (paymentParameters.get("delayAction") as? String)?.uppercase() ?: ""
+                    val delayAction = DelayAction.valueOf(delayActionString);
+                    builder.delayAction(delayAction)
+
                 }
 
                 if(paymentParameters.get("referenceId") != null){

--- a/example/lib/donut_counter_screen.dart
+++ b/example/lib/donut_counter_screen.dart
@@ -26,7 +26,12 @@ class _DonutCounterScreenState extends State<DonutCounterScreen> {
       Payment payment = await _squareMobilePaymentsSdkPlugin.paymentManager
           .startPayment(
               PaymentParameters(
-                processingMode: 0,
+                  autocomplete: false,
+                  delayDuration: 60 * 60, // 1 hour
+                  delayAction: DelayAction.cancel,
+                  note:
+                      "planned cancelled payment. This is used to create a new stored card for customer# 001",
+                  processingMode: 0,
                   amountMoney:
                       Money(amount: amount, currencyCode: CurrencyCode.eur),
                   paymentAttemptId: paymentAttemptId),

--- a/ios/Classes/Mappers/PaymentMapper.swift
+++ b/ios/Classes/Mappers/PaymentMapper.swift
@@ -14,6 +14,14 @@ public class PaymentMapper {
         }
     }
 
+    static func getDelayAction(from delayAction: String) -> DelayAction {
+        switch delayAction.uppercased() {
+        case "cancel": return .cancel
+        case "complete": return .complete
+        default: return .cancel
+        }
+    }
+
     static func getPaymentParameters(paymentParameters: [String: Any]) -> PaymentParameters {
         // Required fields
         guard
@@ -73,7 +81,17 @@ public class PaymentMapper {
         if let note = paymentParameters["note"] as? String {
             paymentParams.note = note
         }
-        
+
+        // Optional: delayDuration
+        if let delayDuration = paymentParameters["delayDuration"] as? Int {
+            paymentParams.delayDuration = TimeInterval(delayDuration)
+        }
+
+        // Optional: delayAction
+        if let delayAction = paymentParameters["delayAction"] as? String {
+            paymentParams.delayAction = getDelayAction(from: delayAction)
+        }
+
         // Optional: orderId
         if let orderId = paymentParameters["orderId"] as? String {
             paymentParams.orderID = orderId


### PR DESCRIPTION
## Summary

Fixes #41 by adding support for delayed payment parameters in the Flutter plugin.

This PR maps `delayDuration` and `delayAction` from Flutter to the native SDKs on both Android and iOS, allowing payments to be configured with delayed completion or cancellation behavior.

## Changes

- Added Android mapping for:
  - `delayDuration`
  - `delayAction`
- Added iOS mapping for:
  - `delayDuration`
  - `delayAction`
- Updated the example app to demonstrate delayed payment usage with:
  - `autocomplete: false`
  - `delayDuration: 60 * 60`
  - `delayAction: DelayAction.cancel`

## Notes

The example uses a 1-hour delay duration and cancel action to demonstrate a planned delayed/cancelled payment flow.

Closes #41