### PR TITLE
Properly build the `PromptParameters` object in `startPayment` to allow customization from Flutter

### DIFF
--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/mappers/PaymentMapper.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/mappers/PaymentMapper.kt
@@ -6,6 +6,8 @@ import com.squareup.sdk.mobilepayments.payment.PaymentParameters
 import com.squareup.sdk.mobilepayments.payment.PromptMode
 import com.squareup.sdk.mobilepayments.payment.PromptParameters
 import com.squareup.sdk.mobilepayments.payment.ProcessingMode
+import com.squareup.sdk.mobilepayments.payment.AdditionalPaymentMethod
+
 import java.util.UUID
 
 class PaymentMapper {
@@ -72,12 +74,28 @@ class PaymentMapper {
             2 -> ProcessingMode.ONLINE_ONLY
             else -> ProcessingMode.AUTO_DETECT
         }
+        
+        fun convertToPromptMode(value: String?) = when (value) {
+            "customMode" -> PromptMode.CUSTOM
+            "defaultMode" -> PromptMode.DEFAULT
+            else -> PromptMode.DEFAULT
+        }
+
+        fun convertToAdditionalPaymentMethod(value: String?): List<AdditionalPaymentMethod.Type> = when (value) {
+            "all" -> listOf(AdditionalPaymentMethod.Type.CASH, AdditionalPaymentMethod.Type.KEYED)
+            "cash" -> listOf(AdditionalPaymentMethod.Type.CASH)
+            "keyed" -> listOf(AdditionalPaymentMethod.Type.KEYED)
+            else -> listOf()
+        }
+
 
         @JvmStatic
         fun getPromptParameters(promptParameters: HashMap<String, Any>): PromptParameters {
-            
+            Log.d("PaymentMapper", promptParameters.get("additionalPaymentMethods") as? String ?: "none")
+            println(promptParameters.get("additionalPaymentMethods") as? String ?: "none")
             return PromptParameters(
-                mode = PromptMode.DEFAULT
+                mode = convertToPromptMode(promptParameters.get("mode") as? String ?: "defaultMode"),
+                additionalPaymentMethods = convertToAdditionalPaymentMethod(promptParameters.get("additionalPaymentMethods") as? String ?: "none")
             )
         }
     }

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/mappers/PaymentMapper.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/mappers/PaymentMapper.kt
@@ -91,8 +91,6 @@ class PaymentMapper {
 
         @JvmStatic
         fun getPromptParameters(promptParameters: HashMap<String, Any>): PromptParameters {
-            Log.d("PaymentMapper", promptParameters.get("additionalPaymentMethods") as? String ?: "none")
-            println(promptParameters.get("additionalPaymentMethods") as? String ?: "none")
             return PromptParameters(
                 mode = convertToPromptMode(promptParameters.get("mode") as? String ?: "defaultMode"),
                 additionalPaymentMethods = convertToAdditionalPaymentMethod(promptParameters.get("additionalPaymentMethods") as? String ?: "none")

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/mappers/PaymentMapper.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/mappers/PaymentMapper.kt
@@ -92,8 +92,8 @@ class PaymentMapper {
         @JvmStatic
         fun getPromptParameters(promptParameters: HashMap<String, Any>): PromptParameters {
             return PromptParameters(
-                mode = convertToPromptMode(promptParameters.get("mode") as? String ?: "defaultMode"),
-                additionalPaymentMethods = convertToAdditionalPaymentMethod(promptParameters.get("additionalPaymentMethods") as? String ?: "none")
+                mode = convertToPromptMode(promptParameters.get("mode") as? String),
+                additionalPaymentMethods = convertToAdditionalPaymentMethod(promptParameters.get("additionalPaymentMethods") as? String)
             )
         }
     }

--- a/doc/README.md
+++ b/doc/README.md
@@ -124,7 +124,7 @@ try {
             amountMoney: Money(amount: 100, currencyCode: CurrencyCode.eur),
             idempotencyKey: idempotencyKey
         ),
-        PromptParameters(additionalPaymentMethods: List.empty(), mode: PromptMode.defaultMode));
+        PromptParameters(mode: PromptMode.defaultMode));
     print('Payment successful:: $payment');
 } catch (e) {
     print('Payment error: $e');

--- a/doc/REFERENCE.md
+++ b/doc/REFERENCE.md
@@ -381,7 +381,10 @@ Defines the actions to be applied to the payment when the delayDuration has elap
 The Type of Payment that is about to take place.
 
 * `all` - Instructs the SDK to begin a payment showing all the available payment methods in the account and device.
+* `cash` - Instructs the SDK to begin a payment for a physical cash transaction.
 * `keyed` - Instructs the SDK to begin a payment for a keyed in credit card.
+* `tapToPay` - Instructs the SDK to begin a payment for a "Tap to Pay" compatible device. (currently only iOS compatible)
+* `null` - Instructs the SDK to begin a payment and only rely on any connected readers.
 
 ---
 

--- a/example/lib/donut_counter_screen.dart
+++ b/example/lib/donut_counter_screen.dart
@@ -31,8 +31,9 @@ class _DonutCounterScreenState extends State<DonutCounterScreen> {
                       Money(amount: amount, currencyCode: CurrencyCode.eur),
                   paymentAttemptId: paymentAttemptId),
               PromptParameters(
-                  additionalPaymentMethods: List.empty(),
-                  mode: PromptMode.defaultMode));
+                  mode: PromptMode.defaultMode,
+                  additionalPaymentMethods: AdditionalPaymentMethodType.all
+              ));
       if (context.mounted) {
         showPaymentDialog(context, payment);
       }

--- a/ios/Classes/Mappers/PaymentMapper.swift
+++ b/ios/Classes/Mappers/PaymentMapper.swift
@@ -88,7 +88,28 @@ public class PaymentMapper {
     }
     
 
+    static func convertToPromptMode(value: String?) -> PromptMode {
+        switch value {
+            case "customMode": return PromptMode.custom
+            case "defaultMode": return PromptMode.default
+            default: return PromptMode.default
+        }
+    }
+
+    static func convertToAdditionalPaymentMethods(value: String?) -> AdditionalPaymentMethods {
+        switch value {
+            case "all": return AdditionalPaymentMethods.all
+            case "cash": return AdditionalPaymentMethods.cash
+            case "keyed": return AdditionalPaymentMethods.keyed
+            case "tapToPay": return AdditionalPaymentMethods.tapToPay
+            default: return AdditionalPaymentMethods()
+        }
+    }
+
     static func getPromptParameters(promptParameters: [String: Any]) -> PromptParameters {
-        return PromptParameters(mode: .default, additionalMethods: .all)
+        return PromptParameters(
+            mode: convertToPromptMode(value: promptParameters["mode"] as? String),
+            additionalMethods: convertToAdditionalPaymentMethods(value: promptParameters["additionalPaymentMethods"] as? String)
+        )
     }
 }

--- a/lib/src/models/enums.dart
+++ b/lib/src/models/enums.dart
@@ -7,7 +7,10 @@ enum AccountType {
 }
 
 enum AdditionalPaymentMethodType {
+  all,
+  cash,
   keyed,
+  tapToPay;
 }
 
 enum AuthorizationState {

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -147,8 +147,8 @@ class ReaderInfo with _$ReaderInfo {
 @freezed
 class PromptParameters with _$PromptParameters {
   const factory PromptParameters({
-    required List<AdditionalPaymentMethodType> additionalPaymentMethods,
     required PromptMode mode,
+    AdditionalPaymentMethodType? additionalPaymentMethods,
   }) = _PromptParameters;
 
   factory PromptParameters.fromJson(Map<String, Object?> json) =>

--- a/lib/src/models/models.freezed.dart
+++ b/lib/src/models/models.freezed.dart
@@ -2450,7 +2450,7 @@ PromptParameters _$PromptParametersFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$PromptParameters {
-  List<AdditionalPaymentMethodType> get additionalPaymentMethods =>
+  AdditionalPaymentMethodType? get additionalPaymentMethods =>
       throw _privateConstructorUsedError;
   PromptMode get mode => throw _privateConstructorUsedError;
 
@@ -2471,7 +2471,7 @@ abstract class $PromptParametersCopyWith<$Res> {
       _$PromptParametersCopyWithImpl<$Res, PromptParameters>;
   @useResult
   $Res call(
-      {List<AdditionalPaymentMethodType> additionalPaymentMethods,
+      {AdditionalPaymentMethodType? additionalPaymentMethods,
       PromptMode mode});
 }
 
@@ -2497,7 +2497,7 @@ class _$PromptParametersCopyWithImpl<$Res, $Val extends PromptParameters>
       additionalPaymentMethods: null == additionalPaymentMethods
           ? _value.additionalPaymentMethods
           : additionalPaymentMethods // ignore: cast_nullable_to_non_nullable
-              as List<AdditionalPaymentMethodType>,
+              as AdditionalPaymentMethodType?,
       mode: null == mode
           ? _value.mode
           : mode // ignore: cast_nullable_to_non_nullable
@@ -2515,7 +2515,7 @@ abstract class _$$PromptParametersImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {List<AdditionalPaymentMethodType> additionalPaymentMethods,
+      {AdditionalPaymentMethodType? additionalPaymentMethods,
       PromptMode mode});
 }
 
@@ -2539,7 +2539,7 @@ class __$$PromptParametersImplCopyWithImpl<$Res>
       additionalPaymentMethods: null == additionalPaymentMethods
           ? _value._additionalPaymentMethods
           : additionalPaymentMethods // ignore: cast_nullable_to_non_nullable
-              as List<AdditionalPaymentMethodType>,
+              as AdditionalPaymentMethodType?,
       mode: null == mode
           ? _value.mode
           : mode // ignore: cast_nullable_to_non_nullable
@@ -2554,21 +2554,18 @@ class _$PromptParametersImpl
     with DiagnosticableTreeMixin
     implements _PromptParameters {
   const _$PromptParametersImpl(
-      {required final List<AdditionalPaymentMethodType>
-          additionalPaymentMethods,
-      required this.mode})
+      {required this.mode,
+      final AdditionalPaymentMethodType?
+          additionalPaymentMethods})
       : _additionalPaymentMethods = additionalPaymentMethods;
 
   factory _$PromptParametersImpl.fromJson(Map<String, dynamic> json) =>
       _$$PromptParametersImplFromJson(json);
 
-  final List<AdditionalPaymentMethodType> _additionalPaymentMethods;
+  final AdditionalPaymentMethodType? _additionalPaymentMethods;
   @override
-  List<AdditionalPaymentMethodType> get additionalPaymentMethods {
-    if (_additionalPaymentMethods is EqualUnmodifiableListView)
-      return _additionalPaymentMethods;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_additionalPaymentMethods);
+  AdditionalPaymentMethodType? get additionalPaymentMethods {
+    return _additionalPaymentMethods;
   }
 
   @override
@@ -2623,15 +2620,14 @@ class _$PromptParametersImpl
 
 abstract class _PromptParameters implements PromptParameters {
   const factory _PromptParameters(
-      {required final List<AdditionalPaymentMethodType>
-          additionalPaymentMethods,
-      required final PromptMode mode}) = _$PromptParametersImpl;
+      {required final PromptMode mode,
+      final AdditionalPaymentMethodType? additionalPaymentMethods}) = _$PromptParametersImpl;
 
   factory _PromptParameters.fromJson(Map<String, dynamic> json) =
       _$PromptParametersImpl.fromJson;
 
   @override
-  List<AdditionalPaymentMethodType> get additionalPaymentMethods;
+  AdditionalPaymentMethodType? get additionalPaymentMethods;
   @override
   PromptMode get mode;
 

--- a/lib/src/models/models.g.dart
+++ b/lib/src/models/models.g.dart
@@ -333,24 +333,21 @@ const _$CardInputMethodEnumMap = {
 _$PromptParametersImpl _$$PromptParametersImplFromJson(
         Map<String, dynamic> json) =>
     _$PromptParametersImpl(
-      additionalPaymentMethods:
-          (json['additionalPaymentMethods'] as List<dynamic>)
-              .map((e) => $enumDecode(_$AdditionalPaymentMethodTypeEnumMap, e))
-              .toList(),
+      additionalPaymentMethods: json['additionalPaymentMethods'] == null ? null : $enumDecode(_$AdditionalPaymentMethodTypeEnumMap, json['additionalPaymentMethods'] as dynamic),
       mode: $enumDecode(_$PromptModeEnumMap, json['mode']),
     );
 
 Map<String, dynamic> _$$PromptParametersImplToJson(
-        _$PromptParametersImpl instance) =>
-    <String, dynamic>{
-      'additionalPaymentMethods': instance.additionalPaymentMethods
-          .map((e) => _$AdditionalPaymentMethodTypeEnumMap[e]!)
-          .toList(),
-      'mode': _$PromptModeEnumMap[instance.mode]!,
-    };
+        _$PromptParametersImpl instance) => <String, dynamic>{
+            'additionalPaymentMethods': instance.additionalPaymentMethods == null ? null : _$AdditionalPaymentMethodTypeEnumMap[instance.additionalPaymentMethods!],
+            'mode': _$PromptModeEnumMap[instance.mode]!,
+          };
 
 const _$AdditionalPaymentMethodTypeEnumMap = {
+  AdditionalPaymentMethodType.all: 'all',
+  AdditionalPaymentMethodType.cash: 'cash',
   AdditionalPaymentMethodType.keyed: 'keyed',
+  AdditionalPaymentMethodType.tapToPay: 'tapToPay'
 };
 
 const _$PromptModeEnumMap = {


### PR DESCRIPTION
The `getPromptParameters` function for both, Android and iOS, used to default to set variables instead of actually accepting whatever the user passed in from the Flutter side. This pull request remedies this by building the `PromptParameters` based on the object the user sends in.

Due to the inconsistent way both sides handle it (Android expects a list of all the payment method types, while iOS only expects a single instance), the `additionalPaymentMethods` field in the `PromptParameters` on the Flutter side has been changed to be a nullable singular type of `AdditionalPaymentMethodType`, and it accepts any of the following:
```
- all
- cash
- keyed
- tapToPay (iOS compatible only, as I couldn't find anything related to this while looking through the Square SDK compiled classes)
- null
```

If there are plans to add more payment method types and you would instead prefer a list, I can go ahead and revert the field back to the way it was (although given that the initializer that accepts an array has been marked as deprecated, I don't think there's plans to revert it.)

The reference file, readme, and example source code have all also been updated to account for this new change. This change was also tested on both, an Android emulator and an iPad 9th Generation, and both ran into no issues.

If there are any issues or feedback, please let me know, as I'd like to get this working as soon as possible.

Thank you for your time!