### PR TITLE
Fix inconsistent processingMode mapping on iOS

### DIFF
--- a/ios/Classes/Mappers/PaymentMapper.swift
+++ b/ios/Classes/Mappers/PaymentMapper.swift
@@ -36,7 +36,7 @@ public class PaymentMapper {
             paymentParams = PaymentParameters(
                 paymentAttemptID: paymentAttemptID,
                 amountMoney: money,
-                processingMode: ProcessingMode(rawValue: processingMode)!
+                processingMode: Self.convertToProcessingMode(processingMode)
             )
         }
         
@@ -87,6 +87,14 @@ public class PaymentMapper {
         return paymentParams
     }
     
+
+    static func convertToProcessingMode(_ value: Int) -> ProcessingMode {
+        switch value {
+        case 1: return .offlineOnly
+        case 2: return .onlineOnly
+        default: return .autoDetect
+        }
+    }
 
     static func getPromptParameters(promptParameters: [String: Any]) -> PromptParameters {
         return PromptParameters(mode: .default, additionalMethods: .all)


### PR DESCRIPTION
## Why
The iOS mapper was using `ProcessingMode(rawValue:)`, but the native enum raw values do not match the Dart `ProcessingMode` indices. That caused `autoDetect` and `onlineOnly` to be interpreted incorrectly on iOS.

Addresses https://github.com/square/mobile-payments-sdk-flutter/issues/75

## What
- Map Dart `processingMode` values to native iOS `ProcessingMode` with an explicit switch
- Default unknown values to `.autoDetect`, matching the existing safe behavior pattern

## Risk Assessment
Low — this is isolated to iOS payment parameter mapping and corrects a mismatched enum conversion.

Generated with Codex
