### PR TITLE
add default case when SDK respond a different error

### DIFF
--- a/ios/Classes/Extensions/AuthorizationExtension.swift
+++ b/ios/Classes/Extensions/AuthorizationExtension.swift
@@ -31,6 +31,7 @@ extension AuthorizationError {
         case .noNetwork: "noNetwork"
         case .unexpected: "unexpected"
         case .unsupportedCountry: "unsupportedCountry"
+        @unknown default: "unexpected"
         }
     }
 }

--- a/ios/Classes/Modules/AuthModule.swift
+++ b/ios/Classes/Modules/AuthModule.swift
@@ -26,8 +26,9 @@ public class AuthModule {
             locationID: locationId
         ) { error in
             if let error {
-                var e = error as NSError
-                if let authError = AuthorizationError(rawValue: e.code) {
+                let e = error as NSError
+                if e.domain == SQMPAuthorizationErrorDomain,
+                   let authError = AuthorizationError(rawValue: e.code) {
                     result(
                         FlutterError(
                             code: authError.getName(),
@@ -40,7 +41,7 @@ public class AuthModule {
                         FlutterError(
                             code: AuthorizationError.unexpected.getName(),
                             message: e.localizedDescription,
-                            details: e.localizedFailureReason
+                            details: e.localizedDescription
                         )
                     )
                 }


### PR DESCRIPTION
Improve authorization error handling and SDK compatibility
Validate SQMPAuthorizationErrorDomain before mapping NSError codes,
use localizedDescription in fallback details, and handle unknown
AuthorizationError cases with @unknown default.

Fixes https://github.com/square/mobile-payments-sdk-flutter/issues/81