### PR TITLE
upgrade native sdks to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,33 @@
 ## 2026.7.4
 
-* Upgrade Android and iOS native SDK to `2.6.0` https://github.com/square/mobile-payments-sdk-flutter/pull/88#:~:text=https%3A//developer.squareup.com/docs/changelog/mobile%2Dlogs/2026%2D07%2D27
-* Add `hostIdMismatch` to `ReaderStatusInfoUnavailableReason` and `ReaderPairingErrorCode`. This surfaces the native `HOST_ID_MISMATCH` reason, reported when a reader refuses a connection because another device was its most-recently-paired host (previously reported as a generic internal/unknown error)
-* Cash payments may now be automatically rounded to the nearest five cents for CAD and AUD, and optionally USD when enabled. Payment results reflect the rounded amount
-* **Breaking (Android):** Removed `externalDetails` from `Payment` (offline and online). The native `ExternalPaymentDetails`, `ExternalTenderType`, and `Payment.externalDetails` APIs were removed in Android native SDK `2.6.0`. `SourceType.externalSource` remains available
+- Upgrade Android and iOS native SDK to `2.6.0`. See the native changelog: [https://developer.squareup.com/docs/changelog/mobile-logs/2026-07-27](https://developer.squareup.com/docs/changelog/mobile-logs/2026-07-27)
+- **(Android)** Add `hostIdMismatch` to `ReaderStatusInfoUnavailableReason` and `ReaderPairingErrorCode`. This surfaces the native `HOST_ID_MISMATCH` reason, reported when a reader refuses a connection because another device was its most-recently-paired host (previously reported as a generic internal/unknown error). This reason is Android-only; iOS `2.6.0` has no equivalent
+- Add `hostIdMismatch` to `ReaderStatusInfoUnavailableReason` and `ReaderPairingErrorCode`. This surfaces the native `HOST_ID_MISMATCH` reason, reported when a reader refuses a connection because another device was its most-recently-paired host (previously reported as a generic internal/unknown error)
+- Cash payments may now be automatically rounded to the nearest five cents for CAD and AUD, and optionally USD when enabled. Payment results reflect the rounded amount
+- Removed the native `ExternalPaymentDetails`, `ExternalTenderType`, and `Payment.externalDetails` APIs (removed in Android native SDK `2.6.0`). This has no impact on the Flutter API: `externalDetails` was never exposed on the Dart `Payment`/`OfflinePayment` models, so no migration is required. `SourceType.externalSource` remains available
+
+
 
 ## 2026.7.3
+
 - Fix issue #84, fix additionalPaymentMethods Map in native side 
 in order to support keyed, cash, tapToPay additional methods
 
+
+
 ## 2026.7.2
+
 - Fix issue #81
 - Improve authorization error handling and SDK compatibility
+
+
 
 ## 2026.7.1
 
 Aligns iOS and Android error handling with exhaustive, typed Dart enums.
 
 ### Breaking changes
+
 - `ReaderManager.pairReader` callback signature changed from `void Function(bool, String?)` to `void Function(bool, ReaderPairingError?)`. The second argument is now a typed `ReaderPairingError` exception instead of a raw message string.
 - `SettingsManager.getTrackingConsentState()` now returns `Future<TrackingConsentState>` (new enum) instead of `Future<String>`.
 - The `ReaderPairingError` *enum* was renamed to `ReaderPairingErrorCode`; `ReaderPairingError` is now an `Exception` class. Several cases were renamed: `bluetoothNotSupported` → `bluetoothUnsupported`, `bondingRemoved` → `bondFailed`, `timedOut` → `timeout`.
@@ -29,18 +39,25 @@ Aligns iOS and Android error handling with exhaustive, typed Dart enums.
 - `OfflinePayment` now has a required `sourceType` field.
 - `linkAppleAccount`, `relinkAppleAccount`, and `isAppleAccountLinked` now throw a typed `TapToPayError` (with `TapToPayErrorCode`) instead of returning/throwing generic strings.
 
+
+
 ### Fixes
+
 - `AuthorizationManager.authorize` now reports a typed error (e.g. on revoked access tokens) instead of an `unknown` code or hanging. (#74)
 - Tracking consent, environment, and currency codes are normalized for `json_serializable`.
 
+
+
 ## 2026.5.1
 
-* Upgrade Android and iOS native SDK to `2.5.0`
-* Add `SettingsManager.isShowingSettings()` to check whether the Settings screen is currently presented
-* Add `SettingsManager.closeSettings()` to programmatically dismiss the Settings screen
-* Add `ReaderManager.readerSettings()` which returns a new `ReaderSettings` object (`isReducedChargingModeEnabled`, `preferredFirmwareUpdateTime`). Adds a new `TimeOfDay` type (`hour`, `minute`) used by `preferredFirmwareUpdateTime`
-* **Breaking:** `ReaderInfo.firmwareVersion` and `ReaderInfo.firmwarePercent` have been replaced by a single `ReaderInfo.firmwareInfo` object of shape `{ version, updatePercentage }`, mirroring the 2.5.0 native API
-* **Breaking (Android):** Removed `ALIPAY`, `CASH_APP`, `SUICA`, `ID`, and `QUICPAY` from the mapped `Card.Brand` values — these were removed in native SDK `2.5.0`
+- Upgrade Android and iOS native SDK to `2.5.0`
+- Add `SettingsManager.isShowingSettings()` to check whether the Settings screen is currently presented
+- Add `SettingsManager.closeSettings()` to programmatically dismiss the Settings screen
+- Add `ReaderManager.readerSettings()` which returns a new `ReaderSettings` object (`isReducedChargingModeEnabled`, `preferredFirmwareUpdateTime`). Adds a new `TimeOfDay` type (`hour`, `minute`) used by `preferredFirmwareUpdateTime`
+- **Breaking:** `ReaderInfo.firmwareVersion` and `ReaderInfo.firmwarePercent` have been replaced by a single `ReaderInfo.firmwareInfo` object of shape `{ version, updatePercentage }`, mirroring the 2.5.0 native API
+- **Breaking (Android):** Removed `ALIPAY`, `CASH_APP`, `SUICA`, `ID`, and `QUICPAY` from the mapped `Card.Brand` values — these were removed in native SDK `2.5.0`
+
+
 
 ## 2026.3.1
 
@@ -56,14 +73,19 @@ Upgrade native SDKs: Android 2.3.4, iOS: 2.3.1
 
 ## 2025.11.1
 
-- Support for paymentAttemptId 
+- Support for paymentAttemptId
+
+
 
 ## 2025.9.1
 
 Upgrade native SDKs: Android 2.3.1, iOS: 2.3.0
 Remove deprecated use of toLower
+
 - Adding consent tracking  
 - (iOS) reader info states
+
+
 
 ## 2025.7.1
 
@@ -78,7 +100,6 @@ Add Reader management support.
 ## 2025.3.0
 
 Add Tap to Pay support for iOS.
-
 
 ## 2025.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2026.7.4
 
-* Upgrade Android and iOS native SDK to `2.6.0`
+* Upgrade Android and iOS native SDK to `2.6.0` https://github.com/square/mobile-payments-sdk-flutter/pull/88#:~:text=https%3A//developer.squareup.com/docs/changelog/mobile%2Dlogs/2026%2D07%2D27
 * Add `hostIdMismatch` to `ReaderStatusInfoUnavailableReason` and `ReaderPairingErrorCode`. This surfaces the native `HOST_ID_MISMATCH` reason, reported when a reader refuses a connection because another device was its most-recently-paired host (previously reported as a generic internal/unknown error)
 * Cash payments may now be automatically rounded to the nearest five cents for CAD and AUD, and optionally USD when enabled. Payment results reflect the rounded amount
 * **Breaking (Android):** Removed `externalDetails` from `Payment` (offline and online). The native `ExternalPaymentDetails`, `ExternalTenderType`, and `Payment.externalDetails` APIs were removed in Android native SDK `2.6.0`. `SourceType.externalSource` remains available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,15 @@
 - Cash payments may now be automatically rounded to the nearest five cents for CAD and AUD, and optionally USD when enabled. Payment results reflect the rounded amount
 - Removed the native `ExternalPaymentDetails`, `ExternalTenderType`, and `Payment.externalDetails` APIs (removed in Android native SDK `2.6.0`). This has no impact on the Flutter API: `externalDetails` was never exposed on the Dart `Payment`/`OfflinePayment` models, so no migration is required. `SourceType.externalSource` remains available
 
-
-
 ## 2026.7.3
 
 - Fix issue #84, fix additionalPaymentMethods Map in native side 
 in order to support keyed, cash, tapToPay additional methods
 
-
-
 ## 2026.7.2
 
 - Fix issue #81
 - Improve authorization error handling and SDK compatibility
-
-
 
 ## 2026.7.1
 
@@ -39,14 +33,10 @@ Aligns iOS and Android error handling with exhaustive, typed Dart enums.
 - `OfflinePayment` now has a required `sourceType` field.
 - `linkAppleAccount`, `relinkAppleAccount`, and `isAppleAccountLinked` now throw a typed `TapToPayError` (with `TapToPayErrorCode`) instead of returning/throwing generic strings.
 
-
-
 ### Fixes
 
 - `AuthorizationManager.authorize` now reports a typed error (e.g. on revoked access tokens) instead of an `unknown` code or hanging. (#74)
 - Tracking consent, environment, and currency codes are normalized for `json_serializable`.
-
-
 
 ## 2026.5.1
 
@@ -56,8 +46,6 @@ Aligns iOS and Android error handling with exhaustive, typed Dart enums.
 - Add `ReaderManager.readerSettings()` which returns a new `ReaderSettings` object (`isReducedChargingModeEnabled`, `preferredFirmwareUpdateTime`). Adds a new `TimeOfDay` type (`hour`, `minute`) used by `preferredFirmwareUpdateTime`
 - **Breaking:** `ReaderInfo.firmwareVersion` and `ReaderInfo.firmwarePercent` have been replaced by a single `ReaderInfo.firmwareInfo` object of shape `{ version, updatePercentage }`, mirroring the 2.5.0 native API
 - **Breaking (Android):** Removed `ALIPAY`, `CASH_APP`, `SUICA`, `ID`, and `QUICPAY` from the mapped `Card.Brand` values — these were removed in native SDK `2.5.0`
-
-
 
 ## 2026.3.1
 
@@ -75,8 +63,6 @@ Upgrade native SDKs: Android 2.3.4, iOS: 2.3.1
 
 - Support for paymentAttemptId
 
-
-
 ## 2025.9.1
 
 Upgrade native SDKs: Android 2.3.1, iOS: 2.3.0
@@ -84,8 +70,6 @@ Remove deprecated use of toLower
 
 - Adding consent tracking  
 - (iOS) reader info states
-
-
 
 ## 2025.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2026.7.4
+
+* Upgrade Android and iOS native SDK to `2.6.0`
+* Add `hostIdMismatch` to `ReaderStatusInfoUnavailableReason` and `ReaderPairingErrorCode`. This surfaces the native `HOST_ID_MISMATCH` reason, reported when a reader refuses a connection because another device was its most-recently-paired host (previously reported as a generic internal/unknown error)
+* Cash payments may now be automatically rounded to the nearest five cents for CAD and AUD, and optionally USD when enabled. Payment results reflect the rounded amount
+* **Breaking (Android):** Removed `externalDetails` from `Payment` (offline and online). The native `ExternalPaymentDetails`, `ExternalTenderType`, and `Payment.externalDetails` APIs were removed in Android native SDK `2.6.0`. `SourceType.externalSource` remains available
+
 ## 2026.7.3
 - Fix issue #84, fix additionalPaymentMethods Map in native side 
 in order to support keyed, cash, tapToPay additional methods

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Mobile Payments SDK for Flutter supports the following SDK versions:
 
-  * [iOS](https://developer.squareup.com/docs/mobile-payments-sdk/ios#1-install-the-sdk-and-dependencies): 2.5.0 and above
-  * [Android](https://developer.squareup.com/docs/mobile-payments-sdk/android#1-install-the-sdk-and-dependencies): 2.5.0 and above
+  * [iOS](https://developer.squareup.com/docs/mobile-payments-sdk/ios#1-install-the-sdk-and-dependencies): 2.6.0 and above
+  * [Android](https://developer.squareup.com/docs/mobile-payments-sdk/android#1-install-the-sdk-and-dependencies): 2.6.0 and above
 
 ## Review requirements
 Before getting started, please review the Requirements and Limitations and Device Compatibility sections to ensure that the SDK can be used in your project:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,14 +3,14 @@ version = "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "2.2.21"
-    ext.squareSdkVersion = "2.5.0"
+    ext.squareSdkVersion = "2.6.0"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.6.0")
+        classpath("com.android.tools.build:gradle:8.11.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ android {
         namespace = "com.squareup.square_mobile_payments_sdk"
     }
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -51,7 +51,7 @@ android {
 
     defaultConfig {
         minSdk = 28
-        targetSdk = 35
+        targetSdk = 36
     }
 
     dependencies {

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/ErrorExtensions.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/ErrorExtensions.kt
@@ -51,5 +51,6 @@ fun PairingErrorCode.toPairingErrorCodeName(): String = when (this) {
     PairingErrorCode.USAGE_ERROR -> "usageError"
     PairingErrorCode.APP_UPDATE_REQUIRED -> "updateRequired"
     PairingErrorCode.INTERNAL_FIRMWARE_ERROR -> "internalFirmwareError"
+    PairingErrorCode.HOST_ID_MISMATCH -> "hostIdMismatch"
     PairingErrorCode.UNKNOWN_ERROR -> "unknown"
 }

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/PaymentExtension.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/PaymentExtension.kt
@@ -4,7 +4,6 @@ import com.squareup.sdk.mobilepayments.payment.Payment
 import com.squareup.sdk.mobilepayments.payment.Money
 import com.squareup.sdk.mobilepayments.payment.Card
 import com.squareup.sdk.mobilepayments.payment.CardPaymentDetails
-import com.squareup.sdk.mobilepayments.payment.ExternalPaymentDetails
 import com.squareup.sdk.mobilepayments.payment.PaymentProcessingFee
 import com.squareup.sdk.mobilepayments.payment.CashPaymentDetails
 
@@ -105,7 +104,6 @@ fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
       "sourceType" to sourceType.toName(), 
       "cashDetails" to cashDetails?.toCashDetailsMap(),
       "cardDetails" to cardDetails?.toOfflineDetailsMap(),
-      "externalDetails" to externalDetails?.toExternalDetailsMap(),
       "uploadedAt" to uploadedAt?.toISO8601String(),
       "localId" to localId,
       "id" to id,
@@ -126,7 +124,6 @@ fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
       "referenceId" to referenceId,
       "sourceType" to sourceType.toName(),
       "cashDetails" to cashDetails?.toCashDetailsMap(),
-      "externalDetails" to externalDetails?.toExternalDetailsMap(),
       "id" to id,
       "processingFee" to processingFee.map { it.toProcessingFeeMap() },
       "status" to status.toStatusName(),
@@ -152,15 +149,6 @@ fun Payment.OfflinePayment.toOfflineMap(): Map<String, Any?> {
     return mapOf(
       "changeBackMoney" to changeBackMoney.toMoneyMap(),
       "buyerSuppliedMoney" to buyerSuppliedMoney.toMoneyMap()
-    )
-  }
-
-  fun ExternalPaymentDetails.toExternalDetailsMap(): Map<String, Any?> {
-    return mapOf(
-      "type" to type,
-      "source" to source,
-      "sourceId" to sourceId,
-      "sourceFeeMoney" to sourceFeeMoney?.toMoneyMap()
     )
   }
 

--- a/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/ReaderExtension.kt
+++ b/android/src/main/kotlin/com/squareup/square_mobile_payments_sdk/extensions/ReaderExtension.kt
@@ -68,6 +68,7 @@ fun ReaderInfo.Status.ReaderUnavailable.toUnavailableReasonName(): String {
         ReaderInfo.Status.ReaderUnavailable.ReaderUnavailableReason.DEVICE_ROOTED -> "deviceRooted"
         ReaderInfo.Status.ReaderUnavailable.ReaderUnavailableReason.DEVICE_DEVELOPER_MODE -> "deviceDeveloperMode"
         ReaderInfo.Status.ReaderUnavailable.ReaderUnavailableReason.DISABLED -> "disabled"
+        ReaderInfo.Status.ReaderUnavailable.ReaderUnavailableReason.HOST_ID_MISMATCH -> "hostIdMismatch"
     }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -37,7 +37,7 @@ android {
     }
 
     dependencies {
-        implementation("com.squareup.sdk:mobile-payments-sdk:2.5.0")
+        implementation("com.squareup.sdk:mobile-payments-sdk:2.6.0")
     }
 
     buildTypes {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.squareup.square_mobile_payments_sdk_example"
-    compileSdk = flutter.compileSdkVersion
+    compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
     packaging {
@@ -31,7 +31,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 28
-        targetSdk = 35
+        targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.21" apply false
 }
 

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,23 +1,14 @@
 PODS:
-  - device_info_plus (0.0.1):
-    - Flutter
   - Flutter (1.0.0)
-  - integration_test (0.0.1):
-    - Flutter
-  - MockReaderUI (2.5.0)
-  - permission_handler_apple (9.3.0):
-    - Flutter
+  - MockReaderUI (2.6.0)
   - square_mobile_payments_sdk (0.0.2):
     - Flutter
-    - MockReaderUI (~> 2.5.0)
-    - SquareMobilePaymentsSDK (~> 2.5.0)
-  - SquareMobilePaymentsSDK (2.5.0)
+    - MockReaderUI (~> 2.6.0)
+    - SquareMobilePaymentsSDK (~> 2.6.0)
+  - SquareMobilePaymentsSDK (2.6.0)
 
 DEPENDENCIES:
-  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
-  - integration_test (from `.symlinks/plugins/integration_test/ios`)
-  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - square_mobile_payments_sdk (from `.symlinks/plugins/square_mobile_payments_sdk/ios`)
 
 SPEC REPOS:
@@ -26,25 +17,16 @@ SPEC REPOS:
     - SquareMobilePaymentsSDK
 
 EXTERNAL SOURCES:
-  device_info_plus:
-    :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
-  integration_test:
-    :path: ".symlinks/plugins/integration_test/ios"
-  permission_handler_apple:
-    :path: ".symlinks/plugins/permission_handler_apple/ios"
   square_mobile_payments_sdk:
     :path: ".symlinks/plugins/square_mobile_payments_sdk/ios"
 
 SPEC CHECKSUMS:
-  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  MockReaderUI: 651252bf60bffc2699866448a6fb7250c06be785
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  square_mobile_payments_sdk: 02e5bb362be05ae223f10bed995d4de1ab38ce34
-  SquareMobilePaymentsSDK: 61d783cb2ef4b238731f4433a42028d95c77893c
+  MockReaderUI: f920dd06eaa41846b5c033da4bc01993b5ad4e50
+  square_mobile_payments_sdk: a112453b1feb62818e30e6f0ffe1c1fdd3e6370a
+  SquareMobilePaymentsSDK: 7fd3fd8f9c3b114d5a0e747bc52120a6edd87c4b
 
 PODFILE CHECKSUM: 40b3d892218f5282302711fd5815e53c97476e73
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		8A8342D6241D68F58E4FC224 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 86017D0F869812A4DC13DB9B /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -42,6 +43,9 @@
 		5B8A97B23401112374F47A15 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = Flutter/ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
+		78DABEA22ED26510000E7860 /* square_mobile_payments_sdk */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = square_mobile_payments_sdk; path = ../../ios/square_mobile_payments_sdk; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		84612A4B0BF5EA1EDAF45109 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		86017D0F869812A4DC13DB9B /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -71,6 +75,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				C50F82702E06160F002FAE15 /* MockReaderUI.xcframework in Frameworks */,
 				C50F826D2E061609002FAE15 /* SquareMobilePaymentsSDK.xcframework in Frameworks */,
 				8A8342D6241D68F58E4FC224 /* Pods_Runner.framework in Frameworks */,
@@ -115,6 +120,9 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78DABEA22ED26510000E7860 /* square_mobile_payments_sdk */,
+				784666492D4C4C64000A1A5F /* FlutterFramework */,
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -193,13 +201,15 @@
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				DB0ECE972D43D78400C8E8BD /* ShellScript */,
 				6E3EF4F914DACEE120D370FC /* [CP] Embed Pods Frameworks */,
-				223991A878CD6F4A92C3CAEE /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
@@ -233,6 +243,9 @@
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -265,23 +278,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		223991A878CD6F4A92C3CAEE /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -758,6 +754,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/example/lib/donut_counter_screen.dart
+++ b/example/lib/donut_counter_screen.dart
@@ -31,7 +31,7 @@ class _DonutCounterScreenState extends State<DonutCounterScreen> {
                   delayAction: DelayAction.cancel,
                   note:
                       "planned cancelled payment. This is used to create a new stored card for customer# 001",
-                  processingMode: 0,
+                  processingMode: 2,
                   amountMoney:
                       Money(amount: amount, currencyCode: CurrencyCode.eur),
                   paymentAttemptId: paymentAttemptId),

--- a/example/lib/donut_counter_screen.dart
+++ b/example/lib/donut_counter_screen.dart
@@ -31,7 +31,7 @@ class _DonutCounterScreenState extends State<DonutCounterScreen> {
                   delayAction: DelayAction.cancel,
                   note:
                       "planned cancelled payment. This is used to create a new stored card for customer# 001",
-                  processingMode: 2,
+                  processingMode: 0,
                   amountMoney:
                       Money(amount: amount, currencyCode: CurrencyCode.eur),
                   paymentAttemptId: paymentAttemptId),

--- a/ios/square_mobile_payments_sdk.podspec
+++ b/ios/square_mobile_payments_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'square_mobile_payments_sdk'
-  s.version          = '0.0.2'
+  s.version          = '0.0.3'
   s.summary          = 'Square Mobile Payments SDK.'
   s.description      = <<-DESC
 Allows developers to take in-person payments using Square hardware.

--- a/ios/square_mobile_payments_sdk.podspec
+++ b/ios/square_mobile_payments_sdk.podspec
@@ -17,8 +17,8 @@ Allows developers to take in-person payments using Square hardware.
   s.dependency 'Flutter'
   s.platform = :ios, '16.0'
 
-  s.dependency "SquareMobilePaymentsSDK", "~> 2.5.0"
-  s.dependency "MockReaderUI", "~> 2.5.0", :configurations => ['Debug']
+  s.dependency "SquareMobilePaymentsSDK", "~> 2.6.0"
+  s.dependency "MockReaderUI", "~> 2.6.0", :configurations => ['Debug']
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/lib/src/models/enums.dart
+++ b/lib/src/models/enums.dart
@@ -183,7 +183,8 @@ enum ReaderStatusInfoUnavailableReason {
   readerNotSupported,
   deviceRooted,
   deviceDeveloperMode,
-  disabled
+  disabled,
+  hostIdMismatch
 }
 
 enum ReaderModel {

--- a/lib/src/models/errors.dart
+++ b/lib/src/models/errors.dart
@@ -114,7 +114,9 @@ enum ReaderPairingErrorCode {
   failedToConnect,
   sandboxNotSupported,
   simulatorNotSupported,
-  readerAlreadyPairing
+  readerAlreadyPairing,
+  // android
+  hostIdMismatch
 }
 
 enum TapToPayErrorCode {

--- a/lib/src/models/errors.dart
+++ b/lib/src/models/errors.dart
@@ -104,6 +104,7 @@ enum ReaderPairingErrorCode {
   bluetoothAlreadyScanning,
   usageError,
   internalFirmwareError,
+  hostIdMismatch,
   // ios
   bluetoothNotReady,
   bluetoothPermissionNotDetermined,
@@ -115,8 +116,6 @@ enum ReaderPairingErrorCode {
   sandboxNotSupported,
   simulatorNotSupported,
   readerAlreadyPairing,
-  // android
-  hostIdMismatch
 }
 
 enum TapToPayErrorCode {

--- a/lib/src/models/models.g.dart
+++ b/lib/src/models/models.g.dart
@@ -256,6 +256,7 @@ const _$ReaderStatusInfoUnavailableReasonEnumMap = {
   ReaderStatusInfoUnavailableReason.deviceRooted: 'deviceRooted',
   ReaderStatusInfoUnavailableReason.deviceDeveloperMode: 'deviceDeveloperMode',
   ReaderStatusInfoUnavailableReason.disabled: 'disabled',
+  ReaderStatusInfoUnavailableReason.hostIdMismatch: 'hostIdMismatch',
 };
 
 _$ReaderFirmwareInfoImpl _$$ReaderFirmwareInfoImplFromJson(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_mobile_payments_sdk
 description: "Square Mobile Payments SDK. Allows developers to take in-person payments using Square hardware."
-version: 2026.7.3
+version: 2026.7.4
 homepage: https://github.com/square/mobile-payments-sdk-flutter
 
 environment:


### PR DESCRIPTION
**Upgrade native SDKs to 2.6.0**
Bumps Android & iOS native SDK to 2.6.0 and Flutter package to 2026.7.4.
- AddedhostIdMismatchreader/pairing error code (nativeHOST_ID_MISMATCH)
- Breaking (Android):removedPayment.externalDetails(removed in native 2.6.0)
- Bumped AGP8.6.0 → 8.11.1and Gradle8.9 → 8.14(required by native 2.6.0'sandroidx.core:1.18.0)
- Updated CHANGELOG