### PR TITLE
Fix issue with returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026.8.1
+
+- Propagate platform errors from manager methods that previously discarded the platform `Future` (`ReaderManager.showMockReaderUI` / `hideMockReaderUI` / `forget` / `blink`, `AuthManager.deauthorize`, `SettingsManager.showSettings`), so callers receive failures instead of unhandled async errors. Also deliver Tap to Pay unsupported-platform errors asynchronously so they can be caught with `await` or `.catchError`.
+
 ## 2026.8.0
 
 The iOS plugin is now distributed as a Swift package. There are no changes to the Dart API.

--- a/lib/src/managers/auth_manager.dart
+++ b/lib/src/managers/auth_manager.dart
@@ -20,6 +20,6 @@ class AuthManager {
   }
 
   Future<void> deauthorize() async {
-    SquareMobilePaymentsSdkPlatform.instance.deauthorize();
+    return SquareMobilePaymentsSdkPlatform.instance.deauthorize();
   }
 }

--- a/lib/src/managers/reader_manager.dart
+++ b/lib/src/managers/reader_manager.dart
@@ -10,11 +10,11 @@ class ReaderManager {
   factory ReaderManager() => _instance;
 
   Future<void> showMockReaderUI() async {
-    SquareMobilePaymentsSdkPlatform.instance.showMockReaderUI();
+    return SquareMobilePaymentsSdkPlatform.instance.showMockReaderUI();
   }
 
   Future<void> hideMockReaderUI() async {
-    SquareMobilePaymentsSdkPlatform.instance.hideMockReaderUI();
+    return SquareMobilePaymentsSdkPlatform.instance.hideMockReaderUI();
   }
 
   Future<List<ReaderInfo>> getReaders() async {
@@ -26,11 +26,11 @@ class ReaderManager {
   }
 
   Future<void> forget(String id) async {
-    SquareMobilePaymentsSdkPlatform.instance.forget(id);
+    return SquareMobilePaymentsSdkPlatform.instance.forget(id);
   }
 
   Future<void> blink(String id) async {
-    SquareMobilePaymentsSdkPlatform.instance.blink(id);
+    return SquareMobilePaymentsSdkPlatform.instance.blink(id);
   }
 
   Future<bool> isPairingInProgress() async {

--- a/lib/src/managers/settings_manager.dart
+++ b/lib/src/managers/settings_manager.dart
@@ -20,7 +20,7 @@ class SettingsManager {
   }
 
   Future<void> showSettings() async {
-    SquareMobilePaymentsSdkPlatform.instance.showSettings();
+    return SquareMobilePaymentsSdkPlatform.instance.showSettings();
   }
 
   Future<TrackingConsentState> getTrackingConsentState() {

--- a/lib/src/managers/tap_to_pay_settings.dart
+++ b/lib/src/managers/tap_to_pay_settings.dart
@@ -7,8 +7,8 @@ class TapToPaySettings {
       TapToPaySettings._privateConstructor();
   factory TapToPaySettings() => _instance;
 
-  static Never _notSupportedError() {
-    throw UnsupportedError('This feature is only available on iOS.');
+  static UnsupportedError _notSupportedError() {
+    return UnsupportedError('This feature is only available on iOS.');
   }
 
   Future<void> linkAppleAccount() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_mobile_payments_sdk
 description: "Square Mobile Payments SDK. Allows developers to take in-person payments using Square hardware."
-version: 2026.8.0
+version: 2026.8.1
 homepage: https://github.com/square/mobile-payments-sdk-flutter
 
 environment:


### PR DESCRIPTION

 Propagate platform errors from manager methods that previously discarded the platform `Future` (`ReaderManager.showMockReaderUI` / `hideMockReaderUI` / `forget` / `blink`, `AuthManager.deauthorize`, `SettingsManager.showSettings`), so callers receive failures instead of unhandled async errors. Also deliver Tap to Pay unsupported-platform errors asynchronously so they can be caught with `await` or `.catchError`.
